### PR TITLE
Match key commands to modifiers exactly

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ editor.registerKeyCommand(boldKeyCommand);
 
 All key commands must have `str` and `run` properties as shown above.
 
-`str` describes the key combination to use and may be a single key, or a modifier and a key separated by `+`.
+`str` describes the key combination to use and may be a single key, or modifier(s) and a key separated by `+`, e.g.: `META+K` (cmd-K), `META+SHIFT+K` (cmd-shift-K)
 
-Modifiers can be one of `CTRL`, `META` or `SHIFT`.
+Modifiers can be any of `CTRL`, `META`, `SHIFT`, or `ALT`.
 
 The key can be any of the alphanumeric characters on the keyboard, or one of the following special keys:
 
@@ -182,7 +182,7 @@ const enterKeyCommand = {
 editor.registerKeyCommand(enterKeyCommand);
 ```
 
-To fall-back to the default behavior, simply return `false` from `run`.
+To fall-back to the default behavior, return `false` from `run`.
 
 ### Configuring text expansions
 

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -8,8 +8,22 @@ import assert from './assert';
 export const MODIFIERS = {
   META: 1, // also called "command" on OS X
   CTRL: 2,
-  SHIFT: 3
+  SHIFT: 4,
+  ALT: 8   // also called "option" on OS X
 };
+
+export function modifierMask(event) {
+  let {
+    metaKey, shiftKey, ctrlKey, altKey
+  } = event;
+  let modVal = (val, modifier) => {
+    return (val && modifier) || 0;
+  };
+  return modVal(metaKey,  MODIFIERS.META) +
+         modVal(shiftKey, MODIFIERS.SHIFT) +
+         modVal(ctrlKey,  MODIFIERS.CTRL) +
+         modVal(altKey,   MODIFIERS.ALT);
+}
 
 export const SPECIAL_KEYS = {
   BACKSPACE: Keycodes.BACKSPACE,
@@ -46,6 +60,7 @@ const Key = class Key {
   constructor(event) {
     this.keyCode = event.keyCode;
     this.event = event;
+    this.modifierMask = modifierMask(event);
   }
 
   static fromEvent(event) {
@@ -102,32 +117,27 @@ const Key = class Key {
   }
 
   hasModifier(modifier) {
-    switch (modifier) {
-      case MODIFIERS.META:
-        return this.metaKey;
-      case MODIFIERS.CTRL:
-        return this.ctrlKey;
-      case MODIFIERS.SHIFT:
-        return this.shiftKey;
-      default:
-        throw new Error(`Cannot check for unknown modifier ${modifier}`);
-    }
+    return modifier & this.modifierMask;
   }
 
   hasAnyModifier() {
-    return this.metaKey || this.ctrlKey || this.shiftKey;
+    return !!this.modifierMask;
   }
 
   get ctrlKey() {
-    return this.event.ctrlKey;
+    return MODIFIERS.CTRL & this.modifierMask;
   }
 
   get metaKey() {
-    return this.event.metaKey;
+    return MODIFIERS.META & this.modifierMask;
   }
 
   get shiftKey() {
-    return this.event.shiftKey;
+    return MODIFIERS.SHIFT & this.modifierMask;
+  }
+
+  get altKey() {
+    return MODIFIERS.ALT & this.modifierMask;
   }
 
   isChar(string) {

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -276,7 +276,8 @@ const DOMHelper = {
   triggerCopyEvent,
   triggerCutEvent,
   triggerPasteEvent,
-  getCopyData
+  getCopyData,
+  createMockEvent
 };
 
 export { triggerEvent };


### PR DESCRIPTION
 * Add `modiferMask` property to key and key commands, use it when finding key commands
 * Changes buildKeyCommand to allow multiple modifiers, i.e. `str: 'META+SHIFT+K'`
 * Add additional assertions to ensure key commands are valid
 * [BREAKING CHANGE] Deprecate using a `modifier` property when creating a key command. This was only used internally for the default key commands, and it unnecessarily limits to a single modifier key.

fixes #216