### PR TITLE
Drop inCard, broke null section positions

### DIFF
--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -37,14 +37,12 @@ const Position = class Position {
   constructor(section, offset=0) {
     this.section = section;
     this.offset = offset;
-    this._inCard = section.isCardSection;
   }
 
   static emptyPosition() {
     return {
       section: null,
       offset: 0,
-      _inCard: false,
       marker: null,
       offsetInTextNode: 0,
       _isEmpty: true,

--- a/tests/acceptance/cursor-position-test.js
+++ b/tests/acceptance/cursor-position-test.js
@@ -199,7 +199,7 @@ test('cursor focused on card wrapper with 0 offset', (assert) => {
   assert.equal(offsets.tail.offset, 0,
                'Cursor tail is positioned at offset 0');
 });
-     
+
 // see https://github.com/bustlelabs/mobiledoc-kit/issues/215
 test('selecting the entire editor element reports a selection range of the entire post', (assert) => {
   let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
@@ -221,14 +221,3 @@ test('selecting the entire editor element reports a selection range of the entir
             'tail section correct');
   assert.equal(offsets.tail.offset, 4, 'tail offset equals section length');
 });
-     
-//inside card wrapper div and before starting zwnj reports its position correctly');
-
-/*
-// These could maybe be done better with arrow keys to get in the cases we want
-// to reproduce. Jumping straight to the DOM nodes in not very acceptancy and may
-// obscure real browser behavior.
-test('cursor inside card wrapper div and after starting zwnj reports its position correctly');
-test('cursor inside card wrapper div and before ending zwnj reports its position correctly');
-test('cursor inside card wrapper div and after ending zwnj reports its position correctly');
-*/

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -242,3 +242,18 @@ test('useful error message when given invalid mobiledoc', (assert) => {
     new Editor({mobiledoc: verybadMobiledoc}); // jshint ignore:line
   }, /unable to parse.*mobiledoc/i);
 });
+
+test('activeSections of a rendered blank mobiledoc is an empty array', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      []
+    ]
+  };
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  assert.equal(0, editor.activeSections.length,
+               'empty activeSections');
+});


### PR DESCRIPTION
By expecting the section to be present, creating a position object with a null section broke. a `null` section value is of dubious worth, however currently needed to fetch `activeSections` for a blank post.