### PR TITLE
Retain edit mode on cloned cards

### DIFF
--- a/src/js/models/card.js
+++ b/src/js/models/card.js
@@ -24,8 +24,16 @@ export default class Card extends Section {
   }
 
   clone() {
-    const payload = shallowCopyObject(this.payload);
-    return this.builder.createCardSection(this.name, payload);
+    let payload = shallowCopyObject(this.payload);
+    let card = this.builder.createCardSection(this.name, payload);
+    // If this card is currently rendered, clone the mode it is
+    // currently in as the default mode of the new card.
+    let mode = this._initialMode;
+    if (this.renderNode && this.renderNode.cardNode) {
+      mode = this.renderNode.cardNode.mode;
+    }
+    card.setInitialMode(mode);
+    return card;
   }
 
   /**

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -2,6 +2,7 @@ import { Editor } from 'mobiledoc-kit';
 import { DIRECTION } from 'mobiledoc-kit/utils/key';
 import Position from 'mobiledoc-kit/utils/cursor/position';
 import Helpers from '../test-helpers';
+import { CARD_MODES } from 'mobiledoc-kit/models/cards';
 
 const { test, module } = Helpers;
 
@@ -441,4 +442,53 @@ test('editor ignores events when focus is inside a card', (assert) => {
   Helpers.dom.triggerEvent(p, 'input');
 
   assert.equal(inputEvents, 1, 'editor handles input event outside of card');
+});
+
+test('a moved card retains its inital editing mode', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    let card = cardSection('simple-card');
+    card.setInitialMode(CARD_MODES.EDIT);
+    return post([
+      markupSection(),
+      card
+    ]);
+  });
+
+  editor = new Editor({mobiledoc, cards: [simpleCard]});
+  editor.render(editorElement);
+
+  assert.hasElement('#edit-button', 'precond - card is in edit mode');
+
+  editor.run(postEditor => {
+    let card = editor.post.sections.tail;
+    postEditor.moveSectionUp(card);
+  });
+
+  assert.hasElement('#edit-button', 'card is still in edit mode');
+});
+
+test('a moved card retains its current editing mode', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      markupSection(),
+      cardSection('simple-card')
+    ]);
+  });
+
+  editor = new Editor({mobiledoc, cards: [simpleCard]});
+  editor.render(editorElement);
+
+  assert.hasNoElement('#edit-button', 'precond - card is not in edit mode');
+
+  let card = editor.post.sections.tail;
+  editor.editCard(card);
+
+  assert.hasElement('#edit-button', 'precond - card is in edit mode');
+
+  editor.run(postEditor => {
+    let card = editor.post.sections.tail;
+    postEditor.moveSectionUp(card);
+  });
+
+  assert.hasElement('#edit-button', 'card is still in edit mode');
 });


### PR DESCRIPTION
In Typeset, @ZeeJab was moving around new cards with the arrow buttons. This caused a card in edit mode to be cloned and moved to the new location. Because initial mode was not set, the card would flop to display and out of edit without a valid payload.

It seems reasonable that a new card would retain the current mode of render as you move it around. This adds logic to `clone` that set the initial mode of the new card correctly.