### PR TITLE
IE11 Support

### DIFF
--- a/src/js/editor/text-expansions.js
+++ b/src/js/editor/text-expansions.js
@@ -88,5 +88,9 @@ export function findExpansion(expansions, keyEvent, editor) {
   const _text = section.textUntil(offset);
   return detect(
     expansions,
-    ({trigger, text}) => key.keyCode === trigger && _text === text);
+    ({trigger, text}) => {
+      return key.keyCode === trigger &&
+             _text === (text + String.fromCharCode(trigger));
+    }
+  );
 }

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -147,8 +147,13 @@ const Cursor = class Cursor {
 
     const range = document.createRange();
     range.setStart(node, offset);
-    this.selection.addRange(range);
-    this.selection.extend(endNode, endOffset);
+    if (direction === DIRECTION.BACKWARD && !!this.selection.extend) {
+      this.selection.addRange(range);
+      this.selection.extend(endNode, endOffset);
+    } else {
+      range.setEnd(endNode, endOffset);
+      this.selection.addRange(range);
+    }
   }
 
   _hasSelection() {

--- a/src/js/utils/lifecycle-callbacks.js
+++ b/src/js/utils/lifecycle-callbacks.js
@@ -17,4 +17,15 @@ export default class LifecycleCallbacksMixin {
     }
     this.callbackQueues[queueName].push(callback);
   }
+  addCallbackOnce(queueName, callback) {
+    if (!queueName) { throw new Error('Must pass queue name to addCallbackOnce'); }
+    let queue = this.callbackQueues[queueName];
+    if (!queue) {
+      this.callbackQueues[queueName] = queue = [];
+    }
+    let index = queue.indexOf(callback);
+    if (index === -1) {
+      queue.push(callback);
+    }
+  }
 }

--- a/src/js/utils/selection-utils.js
+++ b/src/js/utils/selection-utils.js
@@ -11,7 +11,36 @@ function comparePosition(selection) {
 
   const position = anchorNode.compareDocumentPosition(focusNode);
 
-  if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+  // IE may select return focus and anchor nodes far up the DOM tree instead of
+  // picking the deepest, most specific possible node. For example in
+  //
+  //     <div><span>abc</span><span>def</span></div>
+  //
+  // with a cursor between c and d, IE might say the focusNode is <div> with
+  // an offset of 1. However the anchorNode for a selection might still be
+  // <span> 2 if there was a selection.
+  //
+  // This code walks down the DOM tree until a good comparison of position can be
+  // made.
+  //
+  if (position & Node.DOCUMENT_POSITION_CONTAINS) {
+    return comparePosition({
+      focusNode: focusNode.childNodes[focusOffset],
+      focusOffset: 0,
+      anchorNode, anchorOffset
+    });
+  } else if (position & Node.DOCUMENT_POSITION_CONTAINED_BY) {
+    let offset = anchorOffset - 1;
+    if (offset < 0) {
+      offset = 0;
+    }
+    return comparePosition({
+      anchorNode: anchorNode.childNodes[offset],
+      anchorOffset: 0,
+      focusNode, focusOffset
+    });
+  // The meat of translating anchor and focus nodes to head and tail nodes
+  } else if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
     headNode = anchorNode; tailNode = focusNode;
     headOffset = anchorOffset; tailOffset = focusOffset;
     direction = DIRECTION.FORWARD;
@@ -20,11 +49,19 @@ function comparePosition(selection) {
     headOffset = focusOffset; tailOffset = anchorOffset;
     direction = DIRECTION.BACKWARD;
   } else { // same node
-    headNode = anchorNode;
-    tailNode = focusNode;
-    headOffset = Math.min(anchorOffset, focusOffset);
-    tailOffset = Math.max(anchorOffset, focusOffset);
-    direction = null;
+    headNode = tailNode = anchorNode;
+    headOffset = anchorOffset;
+    tailOffset = focusOffset;
+    if (tailOffset < headOffset) {
+      // Swap the offset order
+      headOffset = focusOffset;
+      tailOffset = anchorOffset;
+      direction = DIRECTION.BACKWARD;
+    } else if (headOffset < tailOffset) {
+      direction = DIRECTION.FORWARD;
+    } else {
+      direction = null;
+    }
   }
 
   return {headNode, headOffset, tailNode, tailOffset, direction};

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -104,7 +104,7 @@ test('typing in empty post correctly adds a section to it', (assert) => {
   assert.hasElement('#editor');
   assert.hasNoElement('#editor p');
 
-  Helpers.dom.moveCursorTo($('#editor')[0]);
+  Helpers.dom.moveCursorTo(editorElement);
   Helpers.dom.insertText(editor, 'X');
   assert.hasElement('#editor p:contains(X)');
   Helpers.dom.insertText(editor, 'Y');
@@ -149,6 +149,7 @@ test('typing when on the start of a card is blocked', (assert) => {
 
 // see https://github.com/bustlelabs/mobiledoc-kit/issues/215
 test('select-all and type text works ok', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
     return post([
       markupSection('p', [marker('abc')])
@@ -164,7 +165,9 @@ test('select-all and type text works ok', (assert) => {
   assert.hasElement('#editor p:contains(abc)', 'precond - renders p');
 
   Helpers.dom.insertText(editor, 'X');
-
-  assert.hasNoElement('#editor p:contains(abc)', 'replaces existing text');
-  assert.hasElement('#editor p:contains(X)', 'inserts text');
+  setTimeout(function() {
+    assert.hasNoElement('#editor p:contains(abc)', 'replaces existing text');
+    assert.hasElement('#editor p:contains(X)', 'inserts text');
+    done();
+  }, 0);
 });

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -347,17 +347,17 @@ test('editor ignores events when focus is inside a card', (assert) => {
   assert.hasElement('#simple-card-input', 'precond - renders card');
 
   let inputEvents = 0;
-  editor.handleInput = () => inputEvents++;
+  editor.handleKeyup = () => inputEvents++;
 
   let input = $('#simple-card-input')[0];
-  Helpers.dom.triggerEvent(input, 'input');
+  Helpers.dom.triggerEvent(input, 'keyup');
 
-  assert.equal(inputEvents, 0, 'editor does not handle input event when in card');
+  assert.equal(inputEvents, 0, 'editor does not handle keyup event when in card');
 
   let p = $('#editor p')[0];
-  Helpers.dom.triggerEvent(p, 'input');
+  Helpers.dom.triggerEvent(p, 'keyup');
 
-  assert.equal(inputEvents, 1, 'editor handles input event outside of card');
+  assert.equal(inputEvents, 1, 'editor handles keyup event outside of card');
 });
 
 test('a moved card retains its inital editing mode', (assert) => {

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -44,6 +44,7 @@ function testStatefulCommand({modifier, key, command, markupName}) {
     // command. Skip these tests in IE until we can implement non-parsing
     // text entry.
     test(`${command} applies ${markupName} to next entered text`, (assert) => {
+      let done = assert.async();
       let initialText = 'something';
       const mobiledoc = Helpers.mobiledoc.build(
         ({post, markupSection, marker}) => post([
@@ -59,19 +60,21 @@ function testStatefulCommand({modifier, key, command, markupName}) {
         initialText.length);
       Helpers.dom.triggerKeyCommand(editor, key, modifier);
       Helpers.dom.insertText(editor, 'z');
-
-      let changedMobiledoc = editor.serialize();
-      let expectedMobiledoc = Helpers.mobiledoc.build(
-        ({post, markupSection, marker, markup: buildMarkup}) => {
-          let markup = buildMarkup(markupName);
-          return post([
-            markupSection('p', [
-              marker(initialText),
-              marker('z', [markup])
-            ])
-          ]);
-      });
-      assert.deepEqual(changedMobiledoc, expectedMobiledoc);
+      window.setTimeout(() => {
+        let changedMobiledoc = editor.serialize();
+        let expectedMobiledoc = Helpers.mobiledoc.build(
+          ({post, markupSection, marker, markup: buildMarkup}) => {
+            let markup = buildMarkup(markupName);
+            return post([
+              markupSection('p', [
+                marker(initialText),
+                marker('z', [markup])
+              ])
+            ]);
+        });
+        assert.deepEqual(changedMobiledoc, expectedMobiledoc);
+        done();
+      },0);
     });
   }
 }

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -274,18 +274,23 @@ test('keystroke of printable character while text is selected deletes the text',
 });
 
 test('selecting text bounded by space and typing replaces it', (assert) => {
+  let done = assert.async();
   editor = new Editor({mobiledoc: mobileDocWithSection});
   editor.render(editorElement);
 
   Helpers.dom.selectText('trick', editorElement);
   Helpers.dom.insertText(editor, 'X');
+  window.setTimeout(() => {
+    assert.equal(editor.post.sections.head.text, 'one X pony',
+                 'new text present');
 
-  assert.equal(editor.post.sections.head.text, 'one X pony',
-               'new text present');
-
-  Helpers.dom.insertText(editor, 'Y');
-  assert.equal(editor.post.sections.head.text, 'one XY pony',
-               'further new text present');
+    Helpers.dom.insertText(editor, 'Y');
+    window.setTimeout(() => {
+      assert.equal(editor.post.sections.head.text, 'one XY pony',
+                   'further new text present');
+      done();
+    }, 0);
+  }, 0);
 });
 
 test('selecting all text across sections and hitting enter deletes and moves cursor to empty section', (assert) => {

--- a/tests/acceptance/editor-text-expansions-test.js
+++ b/tests/acceptance/editor-text-expansions-test.js
@@ -23,62 +23,81 @@ module('Acceptance: Editor: Text Expansions', {
 });
 
 test('typing "## " converts to h2', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection}) => post([markupSection()]));
 
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   insertText('## ');
+  window.setTimeout(() => {
+    assert.hasNoElement('#editor p', 'p is gone');
+    assert.hasElement('#editor h2', 'p -> h2');
 
-  assert.hasNoElement('#editor p', 'p is gone');
-  assert.hasElement('#editor h2', 'p -> h2');
-
-  Helpers.dom.insertText(editor, 'X');
-  assert.hasElement('#editor h2:contains(X)', 'text is inserted correctly');
+    Helpers.dom.insertText(editor, 'X');
+    window.setTimeout(() => {
+      assert.hasElement('#editor h2:contains(X)', 'text is inserted correctly');
+      done();
+    }, 0);
+  }, 0);
 });
 
 test('space is required to trigger "## " expansion', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection}) => post([markupSection()]));
 
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   insertText('##X');
-
-  assert.hasElement('#editor p:contains(##X)', 'text inserted, no expansion');
+  window.setTimeout(() => {
+    assert.hasElement('#editor p:contains(##X)', 'text inserted, no expansion');
+    done();
+  });
 });
 
 test('typing "### " converts to h3', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection}) => post([markupSection()]));
 
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   insertText('### ');
+  window.setTimeout(() => {
+    assert.hasNoElement('#editor p', 'p is gone');
+    assert.hasElement('#editor h3', 'p -> h3');
 
-  assert.hasNoElement('#editor p', 'p is gone');
-  assert.hasElement('#editor h3', 'p -> h3');
-
-  Helpers.dom.insertText(editor, 'X');
-  assert.hasElement('#editor h3:contains(X)', 'text is inserted correctly');
+    Helpers.dom.insertText(editor, 'X');
+    window.setTimeout(() => {
+      assert.hasElement('#editor h3:contains(X)', 'text is inserted correctly');
+      done();
+    }, 0);
+  }, 0);
 });
 
 test('typing "* " converts to ul > li', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection}) => post([markupSection()]));
 
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   insertText('* ');
+  window.setTimeout(() => {
+    assert.hasNoElement('#editor p', 'p is gone');
+    assert.hasElement('#editor ul > li', 'p -> "ul > li"');
 
-  assert.hasNoElement('#editor p', 'p is gone');
-  assert.hasElement('#editor ul > li', 'p -> "ul > li"');
-
-  Helpers.dom.insertText(editor, 'X');
-  assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+    Helpers.dom.insertText(editor, 'X');
+    window.setTimeout(() => {
+      assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+      done();
+    }, 0);
+  }, 0);
 });
 
 test('typing "* " inside of a list section does not create a new list section', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, listSection, listItem}) => post([listSection('ul', [listItem()])]));
 
@@ -89,43 +108,57 @@ test('typing "* " inside of a list section does not create a new list section', 
 
   const cursorNode = $('#editor li:eq(0)')[0];
   insertText('* ', cursorNode);
-
-  // note: the actual text is "*&nbsp;", so only check that the "*" is there,
-  // because checking for "* " will fail
-  assert.hasElement('#editor ul > li:contains(*)', 'adds text without expanding it');
+  window.setTimeout(() => {
+    // note: the actual text is "*&nbsp;", so only check that the "*" is there,
+    // because checking for "* " will fail
+    assert.hasElement('#editor ul > li:contains(*)', 'adds text without expanding it');
+    done();
+  }, 0);
 });
 
 test('typing "1 " converts to ol > li', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection}) => post([markupSection()]));
 
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   insertText('1 ');
+  window.setTimeout(() => {
+    assert.hasNoElement('#editor p', 'p is gone');
+    assert.hasElement('#editor ol > li', 'p -> "ol > li"');
 
-  assert.hasNoElement('#editor p', 'p is gone');
-  assert.hasElement('#editor ol > li', 'p -> "ol > li"');
-
-  Helpers.dom.insertText(editor, 'X');
-  assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+    Helpers.dom.insertText(editor, 'X');
+    window.setTimeout(() => {
+      assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+      done();
+    }, 0);
+  }, 0);
 });
 
 test('typing "1. " converts to ol > li', (assert) => {
-  const mobiledoc = Helpers.mobiledoc.build(
-    ({post, markupSection}) => post([markupSection()]));
+  let done = assert.async();
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection}) => {
+    return post([markupSection()]);
+  });
 
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   insertText('1. ');
+  window.setTimeout(() => {
+    assert.hasNoElement('#editor p', 'p is gone');
+    assert.hasElement('#editor ol > li', 'p -> "ol > li"');
 
-  assert.hasNoElement('#editor p', 'p is gone');
-  assert.hasElement('#editor ol > li', 'p -> "ol > li"');
-
-  Helpers.dom.insertText(editor, 'X');
-  assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+    Helpers.dom.insertText(editor, 'X');
+    window.setTimeout(() => {
+      assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+      done();
+    }, 0);
+  }, 0);
 });
 
 test('a new expansion can be registered', (assert) => {
+  let done = assert.async();
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection}) => post([markupSection()]));
 
@@ -138,6 +171,8 @@ test('a new expansion can be registered', (assert) => {
   });
   editor.render(editorElement);
   insertText('quote ');
-
-  assert.ok(didExpand, 'expansion was run');
+  window.setTimeout(() => {
+    assert.ok(didExpand, 'expansion was run');
+    done();
+  }, 0);
 });

--- a/tests/helpers/browsers.js
+++ b/tests/helpers/browsers.js
@@ -2,3 +2,8 @@ export function detectIE() {
   let userAgent = navigator.userAgent;
   return userAgent.indexOf("MSIE ") !== -1 || userAgent.indexOf("Trident/") !== -1 || userAgent.indexOf('Edge/') !== -1;
 }
+
+export function supportsSelectionExtend() {
+  let selection = window.getSelection();
+  return !!selection.extend;
+}

--- a/tests/unit/utils/selection-utils-test.js
+++ b/tests/unit/utils/selection-utils-test.js
@@ -1,0 +1,84 @@
+const {module, test} = QUnit;
+
+import { comparePosition } from 'mobiledoc-kit/utils/selection-utils';
+import { DIRECTION } from 'mobiledoc-kit/utils/key';
+
+module('Unit: Utils: Selection Utils');
+
+test('#comparePosition returns the forward direction of selection', (assert) => {
+  let div = document.createElement('div');
+  div.innerHTML = 'Howdy';
+  let selection = {
+    anchorNode: div,
+    anchorOffset: 0,
+    focusNode: div,
+    focusOffset: 1
+  };
+  let result = comparePosition(selection);
+  assert.equal(DIRECTION.FORWARD, result.direction);
+});
+
+test('#comparePosition returns the backward direction of selection', (assert) => {
+  let div = document.createElement('div');
+  div.innerHTML = 'Howdy';
+  let selection = {
+    anchorNode: div,
+    anchorOffset: 1,
+    focusNode: div,
+    focusOffset: 0
+  };
+  let result = comparePosition(selection);
+  assert.equal(DIRECTION.BACKWARD, result.direction);
+});
+
+test('#comparePosition returns the direction of selection across nodes', (assert) => {
+  let div = document.createElement('div');
+  div.innerHTML = '<span>Howdy</span> <span>Friend</span>';
+  let selection = {
+    anchorNode: div.childNodes[0],
+    anchorOffset: 1,
+    focusNode: div.childNodes[2],
+    focusOffset: 0
+  };
+  let result = comparePosition(selection);
+  assert.equal(DIRECTION.FORWARD, result.direction);
+});
+
+test('#comparePosition returns the backward direction of selection across nodes', (assert) => {
+  let div = document.createElement('div');
+  div.innerHTML = '<span>Howdy</span> <span>Friend</span>';
+  let selection = {
+    anchorNode: div.childNodes[2],
+    anchorOffset: 1,
+    focusNode: div.childNodes[1],
+    focusOffset: 0
+  };
+  let result = comparePosition(selection);
+  assert.equal(DIRECTION.BACKWARD, result.direction);
+});
+
+test('#comparePosition returns the direction of selection with nested nodes', (assert) => {
+  let div = document.createElement('div');
+  div.innerHTML = '<span>Howdy</span> <span>Friend</span>';
+  let selection = {
+    anchorNode: div,
+    anchorOffset: 1,
+    focusNode: div.childNodes[1],
+    focusOffset: 1
+  };
+  let result = comparePosition(selection);
+  assert.equal(DIRECTION.FORWARD, result.direction);
+});
+
+test('#comparePosition returns the backward direction of selection with nested nodes', (assert) => {
+  let div = document.createElement('div');
+  div.innerHTML = '<span>Howdy</span> <span>Friend</span>';
+  let selection = {
+    anchorNode: div.childNodes[2],
+    anchorOffset: 1,
+    focusNode: div,
+    focusOffset: 2
+  };
+  let result = comparePosition(selection);
+  assert.equal(DIRECTION.BACKWARD, result.direction);
+});


### PR DESCRIPTION
This gets tests passing under IE11, and stops using `input` (which is not supported on IE11 contentEditable).

TODO:

* [ ] ~~`input` was triggering a reparse when text content is drag/dropped. Instead of relying on native drag/drop, we should take a cue from other libs and trigger a copy when the user starts dragging. A `drop` can then be a paste event. This is important for us to drag around cards, beyond just restoring old drag behaviors that `input` powered.~~ This behavior is not widely used, and already kind of janky/busted today. Will land this as a followup instead of as part of this commit.
* [x] dropping `input` also breaks text insertion via context menu (like a spelling correction). to restore this functionality, we should look at using `change` events (unknown how viable they are) or DOM mutation events (which are supported in IE11+).