### PR TITLE
Toggle list type sections

### DIFF
--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -1,8 +1,8 @@
 import Key from '../utils/key';
 import { MODIFIERS, SPECIAL_KEYS } from '../utils/key';
 import { filter, reduce } from '../utils/array-utils';
-import Position from '../utils/cursor/position';
 import assert from '../utils/assert';
+import Range from '../utils/cursor/range';
 
 export const DEFAULT_KEY_COMMANDS = [{
   str: 'META+B',
@@ -45,10 +45,12 @@ export const DEFAULT_KEY_COMMANDS = [{
   run(editor) {
     let range = editor.cursor.offsets;
     if (!editor.cursor.hasSelection()) {
-      range.tail = new Position(range.head.section, range.head.section.length);
+      range.tail = range.head.section.tailPosition();
     }
-    let nextPosition = editor.run(postEditor => postEditor.deleteRange(range));
-    editor.cursor.moveToPosition(nextPosition);
+    editor.run(postEditor => {
+      let nextPosition = postEditor.deleteRange(range);
+      postEditor.setRange(new Range(nextPosition));
+    });
   }
 }, {
   str: 'META+K',

--- a/src/js/editor/text-expansions.js
+++ b/src/js/editor/text-expansions.js
@@ -2,35 +2,32 @@ import Keycodes from '../utils/keycodes';
 import Key from '../utils/key';
 import { detect } from '../utils/array-utils';
 import { MARKUP_SECTION_TYPE } from '../models/types';
+import Range from '../utils/cursor/range';
 
 const { SPACE } = Keycodes;
 
 function replaceWithListSection(editor, listTagName) {
   const {head: {section}} = editor.cursor.offsets;
 
-  const newSection = editor.run(postEditor => {
+  editor.run(postEditor => {
     const {builder} = postEditor;
     const listItem = builder.createListItem();
     const listSection = builder.createListSection(listTagName, [listItem]);
 
     postEditor.replaceSection(section, listSection);
-    return listItem;
+    postEditor.setRange(Range.fromSection(listItem));
   });
-
-  editor.cursor.moveToSection(newSection);
 }
 
 function replaceWithHeaderSection(editor, headingTagName) {
   const {head: {section}} = editor.cursor.offsets;
 
-  const newSection = editor.run(postEditor => {
+  editor.run(postEditor => {
     const {builder} = postEditor;
     const newSection = builder.createMarkupSection(headingTagName);
     postEditor.replaceSection(section, newSection);
-    return newSection;
+    postEditor.setRange(Range.fromSection(newSection));
   });
-
-  editor.cursor.moveToSection(newSection);
 }
 
 export function validateExpansion(expansion) {

--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -3,6 +3,7 @@ import Set from '../utils/set';
 
 import LinkedList from '../utils/linked-list';
 import Section from './_section';
+import Position from '../utils/cursor/position';
 
 export default class Markerable extends Section {
   constructor(type, tagName, markers=[]) {
@@ -17,10 +18,24 @@ export default class Markerable extends Section {
     markers.forEach(m => this.markers.append(m));
   }
 
+  canJoin(other) {
+    return other.isMarkerable &&
+      other.type === this.type &&
+      other.tagName === this.tagName;
+  }
+
   clone() {
     const newMarkers = this.markers.map(m => m.clone());
     return this.builder.createMarkerableSection(
       this.type, this.tagName, newMarkers);
+  }
+
+  headPosition() {
+    return new Position(this, 0);
+  }
+
+  tailPosition() {
+    return new Position(this, this.length);
   }
 
   get isBlank() {

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -1,24 +1,28 @@
 import { LIST_ITEM_TYPE } from './types';
 import { normalizeTagName } from '../utils/dom-utils';
 import LinkedItem from '../utils/linked-item';
+import assert from '../utils/assert';
 
 function isChild(section) {
   return section.type === LIST_ITEM_TYPE;
 }
 
+function unimplementedMethod(methodName, me) {
+  throw new Error(`\`${methodName}()\` must be implemented by ${me.constructor.name}`);
+}
+
 export default class Section extends LinkedItem {
   constructor(type) {
     super();
-    if (!type) { throw new Error('Cannot create section without type'); }
+    assert('Cannot create section without type', !!type);
     this.type = type;
     this.isMarkerable = false;
   }
 
   set tagName(val) {
     let normalizedTagName = normalizeTagName(val);
-    if (!this.isValidTagName(normalizedTagName)) {
-      throw new Error(`Cannot set section tagName to ${val}`);
-    }
+    assert(`Cannot set section tagName to ${val}`,
+           this.isValidTagName(normalizedTagName));
     this._tagName = normalizedTagName;
   }
 
@@ -27,15 +31,31 @@ export default class Section extends LinkedItem {
   }
 
   isValidTagName(/* normalizedTagName */) {
-    throw new Error('`isValidTagName` must be implemented by subclass');
+    unimplementedMethod('isValidTagName', this);
   }
 
   get isBlank() {
-    throw new Error('`isBlank` must be implemented by subclass');
+    unimplementedMethod('isBlank', this);
   }
 
   clone() {
-    throw new Error('`clone()` must be implemented by subclass');
+    unimplementedMethod('clone', this);
+  }
+
+  canJoin(/* otherSection */) {
+    unimplementedMethod('canJoin', this);
+  }
+
+  headPosition() {
+    unimplementedMethod('headPosition', this);
+  }
+
+  tailPosition() {
+    unimplementedMethod('tailPosition', this);
+  }
+
+  join() {
+    unimplementedMethod('join', this);
   }
 
   nextLeafSection() {

--- a/src/js/models/card.js
+++ b/src/js/models/card.js
@@ -1,6 +1,7 @@
 import Section from './_section';
 import { CARD_TYPE } from './types';
 import { shallowCopyObject } from '../utils/copy';
+import Position from '../utils/cursor/position';
 
 export const CARD_MODES = {
   DISPLAY: 'display',
@@ -21,6 +22,18 @@ export default class Card extends Section {
 
   get isBlank() {
     return false;
+  }
+
+  canJoin() {
+    return false;
+  }
+
+  headPosition() {
+    return new Position(this, 0);
+  }
+
+  tailPosition() {
+    return new Position(this, 1);
   }
 
   clone() {

--- a/src/js/models/image.js
+++ b/src/js/models/image.js
@@ -1,9 +1,22 @@
 import { IMAGE_SECTION_TYPE } from './types';
 import Section from './_section';
+import Position from '../utils/cursor/position';
 
 export default class Image extends Section {
   constructor() {
     super(IMAGE_SECTION_TYPE);
     this.src = null;
+  }
+
+  canJoin() {
+    return false;
+  }
+
+  headPosition() {
+    return new Position(this, 0);
+  }
+
+  tailPosition() {
+    return new Position(this, 1);
   }
 }

--- a/src/js/models/list-item.js
+++ b/src/js/models/list-item.js
@@ -12,6 +12,7 @@ export const VALID_LIST_ITEM_TAGNAMES = [
 export default class ListItem extends Markerable {
   constructor(tagName, markers=[]) {
     super(LIST_ITEM_TYPE, tagName, markers);
+    this.isListItem = true;
   }
 
   isValidTagName(normalizedTagName) {
@@ -32,10 +33,6 @@ export default class ListItem extends Markerable {
 
     return this._redistributeMarkers(
       beforeSection, afterSection, marker, offset);
-  }
-
-  splitIntoSections() {
-    return this.parent.splitAtListItem(this);
   }
 
   clone() {

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -1,13 +1,8 @@
 import LinkedList from '../utils/linked-list';
-import {
-  forEach,
-  contains
-} from '../utils/array-utils';
+import { forEach, contains } from '../utils/array-utils';
 import { LIST_SECTION_TYPE } from './types';
 import Section from './_section';
-import {
-  normalizeTagName
-} from 'mobiledoc-kit/utils/dom-utils';
+import { normalizeTagName } from '../utils/dom-utils';
 
 export const VALID_LIST_SECTION_TAGNAMES = [
   'ul', 'ol'
@@ -18,20 +13,32 @@ export const DEFAULT_TAG_NAME = VALID_LIST_SECTION_TAGNAMES[0];
 export default class ListSection extends Section {
   constructor(tagName=DEFAULT_TAG_NAME, items=[]) {
     super(LIST_SECTION_TYPE);
-
     this.tagName = tagName;
+    this.isListSection = true;
 
     this.items = new LinkedList({
       adoptItem: i => i.section = i.parent = this,
-      freeItem: i => i.section = i.parent = null
+      freeItem:  i => i.section = i.parent = null
     });
     this.sections = this.items;
 
     items.forEach(i => this.items.append(i));
   }
 
+  canJoin() {
+    return false;
+  }
+
   isValidTagName(normalizedTagName) {
     return contains(VALID_LIST_SECTION_TAGNAMES, normalizedTagName);
+  }
+
+  headPosition() {
+    return this.items.head.headPosition();
+  }
+
+  tailPosition() {
+    return this.items.tail.tailPosition();
   }
 
   get isBlank() {
@@ -44,41 +51,18 @@ export default class ListSection extends Section {
     return newSection;
   }
 
-  // returns [prevListSection, newMarkupSection, nextListSection]
-  // prevListSection and nextListSection may be undefined
-  splitAtListItem(listItem) {
-    if (listItem.parent !== this) {
-      throw new Error('Cannot split list section at item that is not a child');
+  /**
+   * Mutates this list
+   * @param {ListSection|Markerable}
+   * @return null
+   */
+  join(other) {
+    if (other.isListSection) {
+      other.items.forEach(i => this.join(i));
+    } else if (other.isMarkerable) {
+      let item = this.builder.createListItem();
+      item.join(other);
+      this.items.append(item);
     }
-    const prevItem = listItem.prev,
-          nextItem = listItem.next;
-    const listSection = this;
-
-    let prevListSection, nextListSection, newSection;
-
-    newSection = this.builder.createMarkupSection('p');
-    listItem.markers.forEach(m => newSection.markers.append(m.clone()));
-
-    // If there were previous list items, add them to a new list section `prevListSection`
-    if (prevItem) {
-      prevListSection = this.builder.createListSection(this.tagName);
-      let currentItem = listSection.items.head;
-      while (currentItem !== listItem) {
-        prevListSection.items.append(currentItem.clone());
-        currentItem = currentItem.next;
-      }
-    }
-
-    // if there is a next item, add it and all after it to the `nextListSection`
-    if (nextItem) {
-      nextListSection = this.builder.createListSection(this.tagName);
-      let currentItem = nextItem;
-      while (currentItem) {
-        nextListSection.items.append(currentItem.clone());
-        currentItem = currentItem.next;
-      }
-    }
-
-    return [prevListSection, newSection, nextListSection];
   }
 }

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -19,6 +19,7 @@ export const DEFAULT_TAG_NAME = VALID_MARKUP_SECTION_TAGNAMES[0];
 const MarkupSection = class MarkupSection extends Markerable {
   constructor(tagName=DEFAULT_TAG_NAME, markers=[]) {
     super(MARKUP_SECTION_TYPE, tagName, markers);
+    this.isMarkupSection = true;
   }
 
   isValidTagName(normalizedTagName) {
@@ -33,7 +34,6 @@ const MarkupSection = class MarkupSection extends Markerable {
 
     return this._redistributeMarkers(beforeSection, afterSection, marker, offset);
   }
-
 };
 
 export default MarkupSection;

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -119,15 +119,19 @@ export default class Post {
   walkLeafSections(range, callback) {
     const { head, tail } = range;
 
+    let nextSection, shouldStop;
     let currentSection = head.section;
 
     while (currentSection) {
+      nextSection = this._nextLeafSection(currentSection);
+      shouldStop = currentSection === tail.section;
+
       callback(currentSection);
 
-      if (currentSection === tail.section) {
+      if (shouldStop) {
         break;
       } else {
-        currentSection = this._nextLeafSection(currentSection);
+        currentSection = nextSection;
       }
     }
   }

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -78,17 +78,6 @@ const Cursor = class Cursor {
     return this.post.sections.readRange(head.section, tail.section);
   }
 
-  // moves cursor to the start of the section
-  moveToSection(section, offsetInSection=0) {
-    this.moveToPosition(new Position(section, offsetInSection));
-  }
-
-  selectSections(sections) {
-    const headSection = sections[0], tailSection = sections[sections.length - 1];
-    const range = Range.create(headSection, 0, tailSection, tailSection.length);
-    this.selectRange(range);
-  }
-
   _findNodeForPosition(position) {
     const { section } = position;
     let node, offset;
@@ -124,10 +113,6 @@ const Cursor = class Cursor {
 
   selectedText() {
     return this.selection.toString();
-  }
-
-  moveToPosition(position) {
-    this.selectRange(new Range(position, position));
   }
 
   /**

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -2,17 +2,21 @@ import Position from './position';
 import { DIRECTION } from '../key';
 
 export default class Range {
-  constructor(head, tail, direction) {
+  constructor(head, tail=head, direction=DIRECTION.FORWARD) {
     this.head = head;
     this.tail = tail;
     this.direction = direction;
   }
 
-  static create(headSection, headOffset, tailSection, tailOffset) {
+  static create(headSection, headOffset, tailSection=headSection, tailOffset=headOffset) {
     return new Range(
       new Position(headSection, headOffset),
       new Position(tailSection, tailOffset)
     );
+  }
+
+  static fromSection(section) {
+    return new Range(section.headPosition(), section.tailPosition());
   }
 
   static emptyRange() {
@@ -26,6 +30,7 @@ export default class Range {
    * FIXME -- if the section isn't the head or tail, it's assumed to be
    * wholly contained. It's possible to call `trimTo` with a selection that is
    * outside of the range, though, which would invalidate that assumption.
+   * There's no efficient way to determine if a section is within a range, yet.
    */
   trimTo(section) {
     const length = section.length;
@@ -47,6 +52,11 @@ export default class Range {
       default:
         return new Range(this.head, this.tail, direction).moveFocusedPosition(direction);
     }
+  }
+
+  isEqual(other) {
+    return this.head.isEqual(other.head) &&
+           this.tail.isEqual(other.tail);
   }
 
   // "legacy" APIs

--- a/src/js/utils/lifecycle-callbacks.js
+++ b/src/js/utils/lifecycle-callbacks.js
@@ -1,31 +1,25 @@
-import { forEach } from './array-utils';
+import assert from './assert';
 
 export default class LifecycleCallbacksMixin {
   get callbackQueues() {
-    if (!this._callbackQueues) { this._callbackQueues = {}; }
+    this._callbackQueues = this._callbackQueues || {};
     return this._callbackQueues;
   }
   runCallbacks(queueName, args=[]) {
-    if (!queueName) { throw new Error('Must pass queue name to runCallbacks'); }
-    const callbacks = this.callbackQueues[queueName] || [];
-    forEach(callbacks, cb => cb(...args));
+    this._getQueue(queueName).forEach(cb => cb(...args));
   }
   addCallback(queueName, callback) {
-    if (!queueName) { throw new Error('Must pass queue name to addCallback'); }
-    if (!this.callbackQueues[queueName]) {
-      this.callbackQueues[queueName] = [];
-    }
-    this.callbackQueues[queueName].push(callback);
+    this._getQueue(queueName).push(callback);
   }
   addCallbackOnce(queueName, callback) {
-    if (!queueName) { throw new Error('Must pass queue name to addCallbackOnce'); }
-    let queue = this.callbackQueues[queueName];
-    if (!queue) {
-      this.callbackQueues[queueName] = queue = [];
-    }
-    let index = queue.indexOf(callback);
-    if (index === -1) {
+    let queue = this._getQueue(queueName);
+    if (queue.indexOf(callback) === -1) {
       queue.push(callback);
     }
+  }
+  _getQueue(queueName) {
+    assert('Must pass queue name to runCallbacks', !!queueName);
+    this.callbackQueues[queueName] = this.callbackQueues[queueName] || [];
+    return this.callbackQueues[queueName];
   }
 }

--- a/src/js/utils/linked-list.js
+++ b/src/js/utils/linked-list.js
@@ -37,6 +37,12 @@ export default class LinkedList {
     let nextItem = prevItem ? prevItem.next : this.head;
     this.insertBefore(item, nextItem);
   }
+  _ensureItemIsNotAlreadyInList(item){
+    assert(
+      'Cannot insert an item into a list if it is already in a list',
+      !item.next && !item.prev && this.head !== item
+    );
+  }
   insertBefore(item, nextItem) {
     this._ensureItemIsNotInList(item);
     this.adoptItem(item);
@@ -108,8 +114,7 @@ export default class LinkedList {
     let item = this.head;
     let index = 0;
     while (item) {
-      callback(item, index);
-      index++;
+      callback(item, index++);
       item = item.next;
     }
   }

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -1,6 +1,6 @@
 import { Editor } from 'mobiledoc-kit';
 import { DIRECTION } from 'mobiledoc-kit/utils/key';
-import Position from 'mobiledoc-kit/utils/cursor/position';
+import Range from 'mobiledoc-kit/utils/cursor/range';
 import Helpers from '../test-helpers';
 import { CARD_MODES } from 'mobiledoc-kit/models/card';
 
@@ -135,7 +135,7 @@ test('delete when cursor is positioned at end of a card deletes card, replace wi
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasNoElement('#editor p', 'precond - has no markup section');
 
-  editor.cursor.moveToPosition(new Position(editor.post.sections.head, 1));
+  editor.selectRange(Range.create(editor.post.sections.head, 1));
   Helpers.dom.triggerDelete(editor);
 
   assert.hasNoElement('#my-simple-card', 'removes card after delete');
@@ -156,7 +156,7 @@ test('delete when cursor is at start of a card and prev section is blank deletes
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasElement('#editor p', 'precond - has blank markup section');
 
-  editor.cursor.moveToPosition(new Position(editor.post.sections.tail, 0));
+  editor.selectRange(Range.create(editor.post.sections.tail, 0));
   Helpers.dom.triggerDelete(editor);
 
   assert.hasElement('#my-simple-card', 'card still exists after delete');
@@ -174,7 +174,7 @@ test('forward-delete when cursor is positioned at start of a card deletes card, 
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasNoElement('#editor p', 'precond - has no markup section');
 
-  editor.cursor.moveToPosition(new Position(editor.post.sections.head, 0));
+  editor.selectRange(Range.create(editor.post.sections.head, 0));
   Helpers.dom.triggerDelete(editor, DIRECTION.FORWARD);
 
   assert.hasNoElement('#my-simple-card', 'removes card after delete');
@@ -195,7 +195,7 @@ test('forward-delete when cursor is positioned at end of a card and next section
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasElement('#editor p', 'precond - has blank markup section');
 
-  editor.cursor.moveToPosition(new Position(editor.post.sections.head, 1));
+  editor.selectRange(Range.create(editor.post.sections.head, 1));
   Helpers.dom.triggerDelete(editor, DIRECTION.FORWARD);
 
   assert.hasElement('#my-simple-card', 'still has card after delete');
@@ -258,7 +258,7 @@ test('deleting at start of empty markup section with prev card deletes the marku
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasElement('#editor p', 'precond - has blank markup section');
 
-  editor.cursor.moveToPosition(new Position(editor.post.sections.tail, 0));
+  editor.selectRange(Range.create(editor.post.sections.tail, 0));
   Helpers.dom.triggerDelete(editor);
 
   assert.hasElement('#my-simple-card', 'has card after delete');
@@ -282,7 +282,7 @@ test('press enter at end of card inserts section after card', (assert) => {
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasNoElement('#editor p', 'precond - has no markup section');
 
-  editor.cursor.moveToPosition(new Position(editor.post.sections.tail, 1));
+  editor.selectRange(Range.create(editor.post.sections.tail, 1));
   Helpers.dom.triggerEnter(editor);
 
   assert.hasElement('#my-simple-card', 'has card after enter');
@@ -308,7 +308,7 @@ test('press enter at start of card inserts section before card', (assert) => {
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasNoElement('#editor p', 'precond - has no markup section');
 
-  editor.cursor.moveToPosition(new Position(editor.post.sections.tail, 0));
+  editor.selectRange(Range.create(editor.post.sections.tail, 0));
   Helpers.dom.triggerEnter(editor);
 
   assert.hasElement('#my-simple-card', 'has card after enter');

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -1,5 +1,6 @@
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
+import Range from 'mobiledoc-kit/utils/cursor/range';
 
 const { test, module } = Helpers;
 
@@ -264,7 +265,7 @@ test('pasting when on the end of a card is blocked', (assert) => {
   Helpers.dom.selectText('abc', editorElement);
   Helpers.dom.triggerCopyEvent(editor);
 
-  editor.cursor.moveToSection(editor.post.sections.head, 0);
+  editor.selectRange(new Range(editor.post.sections.head.headPosition()));
   Helpers.dom.triggerPasteEvent(editor);
 
   let updatedMobiledoc = editor.serialize();
@@ -278,7 +279,7 @@ test('pasting when on the end of a card is blocked', (assert) => {
     ]
   ], 'no paste has occurred');
 
-  editor.cursor.moveToSection(editor.post.sections.head, 1);
+  editor.selectRange(new Range(editor.post.sections.head.tailPosition()));
   Helpers.dom.triggerPasteEvent(editor);
 
   updatedMobiledoc = editor.serialize();

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -384,7 +384,6 @@ test('selecting text that starts in a list item and ends in a markup section', (
 
   Helpers.dom.selectText('23', editorElement, 'de', editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');
-
   Helpers.dom.triggerDelete(editor);
 
   assert.hasElement('#editor li:contains(1f)',

--- a/tests/unit/utils/linked-list-test.js
+++ b/tests/unit/utils/linked-list-test.js
@@ -40,7 +40,7 @@ INSERTION_METHODS.forEach(method => {
     assert.equal(adoptedItem, item, 'item is adopted');
   });
 
-  test(`#${method} throws if item is in this list`, (assert) => {
+  test(`#${method} throws when inserting item that is already in this list`, (assert) => {
     let list = new LinkedList();
     let item = new LinkedItem();
     list[method](item);
@@ -298,6 +298,25 @@ test(`#forEach iterates one`, (assert) => {
   assert.deepEqual(indexes, [0], 'indexes correct');
 });
 
+test('#forEach exits early if item is removed by callback', (assert) => {
+  let list = new LinkedList();
+  [0,1,2].forEach(val => {
+    let i = new LinkedItem();
+    i.value = val;
+    list.append(i);
+  });
+
+  let iterated = [];
+  list.forEach((item, index) => {
+    iterated.push(item.value);
+    if (index === 1) {
+      list.remove(item); // iteration stops, skipping value 2
+    }
+  });
+
+  assert.deepEqual(iterated, [0,1], 'iteration stops when item.next is null');
+});
+
 test(`#readRange walks from start to end`, (assert) => {
   let list = new LinkedList();
   let itemOne = new LinkedItem();
@@ -492,30 +511,6 @@ test('#removeBy calls `freeItem` for each item removed', (assert) => {
   list.removeBy(i => i.shouldRemove);
 
   assert.deepEqual(freed, [items[0], items[1]]);
-});
-
-test('#insertBefore throws if item to be inserted is already in this list', (assert) => {
-  let item1 = new LinkedItem();
-  let list1 = new LinkedList();
-  list1.append(item1);
-
-  assert.throws(() => {
-    list1.insertBefore(item1, null);
-  });
-});
-
-test('#insertBefore throws if item to be inserted is in another non-empty list', (assert) => {
-  let item1 = new LinkedItem();
-  let item2 = new LinkedItem();
-  let list1 = new LinkedList();
-  list1.append(item1);
-  list1.append(item2);
-
-  let list2 = new LinkedList();
-
-  assert.throws(() => {
-    list2.insertBefore(item1, null);
-  });
 });
 
 test('#every', (assert) => {


### PR DESCRIPTION
Add `postEditor#toggleSection`, `postEditor#setRange`, `editor#selectRange` APIs

`toggleSection` is list-section and list-item aware and will toggle a markup section to/from a list item. Toggling a markup section that is adjacent to a list will join it with that list. Toggling a list item will turn it into a markup section and separate it from the before/after list section. The postEditor run loop will join contiguous list sections of the same type during the before_complete callback queue. This means that deleting a markup section that was between two lists will also cause the lists to be joined together. 

There is some internal refactoring of the cursor movement/selection methods. It is possible that a postEditor method returns a position that has a `section` property that is no longer part of the post abstract after the postEditor's `run()` finishes. This can happen when a markup section is turned into a listSection+listItem and then (in the before_complete queue) merged with an adjacent list.
As a result, it is no longer always safe to use a returned `Position` with a call to one of the cursor movement methods on `editor.cursor` (e.g. moveToPosition/selectRange/selectSection). The `postEditor#setRange` method is added to handle this case.
Mutation methods on the postEditor that could destroy/detach a section can now introspect the current range and update it if they are removing/changing a section that is part of the active `range`. The `postEditor#_joinContiguousListSections` is the only method that does this so far, but eventually all of the methods should be updated to update an active range when necessary. The postEditor automatically renders the updated range at the end of its run loop if `postEditor#setRange` was called.

This is ready for review and merge. If this looks good I will update the documentation to reflect the new APIs shortly before/after merging.

### Possible breaking changes

  * removal of the following methods on `cursor`:
    * `selectSections`, `moveToSection`, `moveToPosition`. None of these was explicitly marked as public.
  * removal of `editor#moveToPosition`. This was not explicitly public before
  * The README mentions `editor#moveToSection`, but this API did not actually exist (it should have been `editor.cursor.moveToSection`). After merge I'll fix up this part of the readme

![abc](https://cloud.githubusercontent.com/assets/2023/11641327/b7c278e2-9d05-11e5-8240-c8dbfeffcf4c.gif)

fixes #186 
