### PR TITLE
Document parser hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,47 @@ const expansion = {
 };
 ```
 
+### DOM Parsing hooks
+
+A developer can override the default parsing behavior for leaf DOM nodes in
+pasted HTML.
+
+For example, when an `img` tag is pasted it may be appropriate to
+fetch that image, upload it to an authoritative source, and create a specific
+kind of image card with the new URL in its payload.
+
+A demonstration of this:
+
+```js
+function imageToCardParser(node, builder, {addSection, addMarkerable, nodeFinished}) {
+  if (node.nodeType !== 1 || node.tagName !== 'IMG') {
+    return;
+  }
+  var payload = { src: node.src };
+  var cardSection = builder.createCardSection('my-image', payload);
+  addSection(cardSection);
+  nodeFinished();
+}
+var options = {
+  parserPlugins: [imageToCardParser]
+};
+var editor = new Mobiledoc.Editor(options);
+var element = document.querySelector('#editor');
+editor.render(element);
+```
+
+Parser hooks are called with two arguments:
+
+* `node` - The node of DOM being parsed. This may be a text node or an element.
+* `builder` - The abstract model builder.
+* `env` - An object containing three callbacks to modify the abstract
+  * `addSection` - Close the current section and add a new one
+  * `addMarkerable` - Add a markerable (marker or atom) to the current section
+  * `nodeFinished` - Bypass all remaining parse steps for this node
+
+Note that you *must* call `nodeFinished` to stop a DOM node from being
+parsed by the next plugin or the default parser.
+
 ### Contributing
 
 Fork the repo, write a test, make a change, open a PR.

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -79,7 +79,7 @@ class Editor {
     this._elementListeners = [];
     this._views = [];
     this.isEditable = null;
-    this._cardParsers = options.cardParsers || [];
+    this._parserPlugins = options.parserPlugins || [];
 
     // FIXME: This should merge onto this.options
     mergeWithOptions(this, defaults, options);
@@ -735,7 +735,7 @@ class Editor {
       this.handleDeletion();
     }
 
-    let pastedPost = parsePostFromPaste(event, this.builder, this._cardParsers);
+    let pastedPost = parsePostFromPaste(event, this.builder, this._parserPlugins);
 
     this.run(postEditor => {
       let nextPosition = postEditor.insertPost(position, pastedPost);

--- a/src/js/utils/paste-utils.js
+++ b/src/js/utils/paste-utils.js
@@ -24,7 +24,7 @@ export function setClipboardCopyData(copyEvent, editor) {
   clipboardData.setData('text/html', html);
 }
 
-export function parsePostFromPaste(pasteEvent, builder, cardParsers=[]) {
+export function parsePostFromPaste(pasteEvent, builder, plugins=[]) {
   let mobiledoc, post;
   const mobiledocRegex = new RegExp(/data\-mobiledoc='(.*?)'>/);
 
@@ -35,7 +35,7 @@ export function parsePostFromPaste(pasteEvent, builder, cardParsers=[]) {
     mobiledoc = JSON.parse(mobiledocString);
     post = mobiledocParsers.parse(builder, mobiledoc);
   } else {
-    post = new HTMLParser(builder, {cardParsers}).parse(html);
+    post = new HTMLParser(builder, {plugins}).parse(html);
   }
 
   return post;

--- a/tests/unit/parsers/dom-google-docs-test.js
+++ b/tests/unit/parsers/dom-google-docs-test.js
@@ -79,12 +79,11 @@ Object.keys(GoogleDocs).forEach(key => {
 test('img in span can use a cardParser to turn img into image-card', function(assert) {
   let example = GoogleDocs['img in span'];
   let options = {
-    cardParsers: [{
-      parse(element, builder) {
-        if (element.tagName === 'IMG') {
-          let payload = {url: element.src};
-          return builder.createCardSection('image-card', payload);
-        }
+    plugins: [function(element, builder, {addSection}) {
+      if (element.tagName === 'IMG') {
+        let payload = {url: element.src};
+        let cardSection = builder.createCardSection('image-card', payload);
+        addSection(cardSection);
       }
     }]
   };


### PR DESCRIPTION
Introduce a public API for parser hooks.

TODO

* [x] Get general :+1: from @bantic 
* [x] Tests
* [x] Refactor to the documented API
* [x] Port existing hook usage here and in TypeSet, smoke test

Fixes https://github.com/bustlelabs/mobiledoc-kit/issues/229