### PR TITLE
Fix issue #256:  Copy-pasting from Notepad does not work

### DIFF
--- a/src/js/utils/paste-utils.js
+++ b/src/js/utils/paste-utils.js
@@ -30,6 +30,11 @@ export function parsePostFromPaste(pasteEvent, builder, plugins=[]) {
 
   let html = pasteEvent.clipboardData.getData('text/html');
 
+  // Fallback to 'text/plain'
+  if (!html || html.length === 0) {
+    html = pasteEvent.clipboardData.getData('text/plain');
+  }
+
   if (mobiledocRegex.test(html)) {
     let mobiledocString = html.match(mobiledocRegex)[1];
     mobiledoc = JSON.parse(mobiledocString);

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -42,6 +42,24 @@ test('simple copy-paste at end of section works', (assert) => {
   assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
 });
 
+test('paste from external text source', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  let textNode = $('#editor p')[0].childNodes[0];
+  assert.equal(textNode.textContent, 'abc'); //precond
+  Helpers.dom.moveCursorTo(textNode, textNode.length);
+
+  Helpers.dom.setCopyData('text/plain', 'abc');
+  Helpers.dom.triggerPasteEvent(editor);
+
+  assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
+});
+
 test('can cut and then paste content', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -291,6 +291,10 @@ function getCopyData(type) {
   return lastCopyData[type];
 }
 
+function setCopyData(type, value) {
+  lastCopyData[type] = value;
+}
+
 function fromHTML(html) {
   html = $.trim(html);
   let div = document.createElement('div');
@@ -319,6 +323,7 @@ const DOMHelper = {
   triggerCutEvent,
   triggerPasteEvent,
   getCopyData,
+  setCopyData,
   createMockEvent
 };
 


### PR DESCRIPTION
A PR that addresses https://github.com/bustlelabs/mobiledoc-kit/issues/256. Fallback to `text/plain` if `text/html` is empty.