### PR TITLE
Refactor postEditor#insertPost to handle more situations

### DIFF
--- a/src/js/editor/post/post-inserter.js
+++ b/src/js/editor/post/post-inserter.js
@@ -1,0 +1,266 @@
+import assert from 'mobiledoc-kit/utils/assert';
+import {
+  MARKUP_SECTION_TYPE,
+  LIST_SECTION_TYPE,
+  POST_TYPE,
+  CARD_TYPE,
+  IMAGE_SECTION_TYPE,
+  LIST_ITEM_TYPE,
+} from 'mobiledoc-kit/models/types';
+import Range from 'mobiledoc-kit/utils/cursor/range';
+
+const MARKERABLE = 'markerable',
+      NESTED_MARKERABLE = 'nested_markerable',
+      NON_MARKERABLE = 'non_markerable';
+
+class Visitor {
+  constructor(inserter, cursorPosition) {
+    let { postEditor, post } = inserter;
+    this.postEditor = postEditor;
+    this._post = post;
+    this.cursorPosition = cursorPosition;
+    this.builder = this.postEditor.builder;
+
+    this._hasInsertedFirstLeafSection = false;
+  }
+
+  get cursorPosition() {
+    return this._cursorPosition;
+  }
+
+  set cursorPosition(position) {
+    this._cursorPosition = position;
+    this.postEditor.setRange(new Range(position));
+  }
+
+  visit(node) {
+    let method = node.type;
+    assert(`Cannot visit node of type ${node.type}`, !!this[method]);
+    this[method](node);
+  }
+
+  _canMergeSection(section) {
+    if (this._hasInsertedFirstLeafSection) {
+      return false;
+    } else {
+      return this._isMarkerable && section.isMarkerable;
+    }
+  }
+
+  get _isMarkerable() {
+    return this.cursorSection.isMarkerable;
+  }
+
+  get cursorSection() {
+    return this.cursorPosition.section;
+  }
+
+  get cursorOffset() {
+    return this.cursorPosition.offset;
+  }
+
+  get _isNested() {
+    return this.cursorSection.isNested;
+  }
+
+  [POST_TYPE](node) {
+    if (this.cursorSection.isBlank && !this._isNested) {
+      // replace blank section with entire post
+      let newSections = node.sections.map(s => s.clone());
+      this._replaceSection(this.cursorSection, newSections);
+      this.cursorPosition = newSections[newSections.length - 1].tailPosition();
+    } else {
+      node.sections.forEach(section => this.visit(section));
+    }
+  }
+
+  [MARKUP_SECTION_TYPE](node) {
+    this[MARKERABLE](node);
+  }
+
+  [LIST_SECTION_TYPE](node) {
+    let hasNext = !!node.next;
+    node.items.forEach(item => this.visit(item));
+
+    if (this._isNested && hasNext) {
+      this._breakNestedAtCursor();
+    }
+  }
+
+  [LIST_ITEM_TYPE](node) {
+    this[NESTED_MARKERABLE](node);
+  }
+
+  [CARD_TYPE](node) {
+    this[NON_MARKERABLE](node);
+  }
+
+  [IMAGE_SECTION_TYPE](node) {
+    this[NON_MARKERABLE](node);
+  }
+
+  [NON_MARKERABLE](section) {
+    if (this._isNested) {
+      this._breakNestedAtCursor();
+    } else if (!this.cursorSection.isBlank) {
+      this._breakAtCursor();
+    }
+
+    this._insertLeafSection(section);
+  }
+
+  [MARKERABLE](section) {
+    if (this._canMergeSection(section)) {
+      this._mergeSection(section);
+    } else {
+      this._breakAtCursor();
+      this._insertLeafSection(section);
+    }
+  }
+
+  [NESTED_MARKERABLE](section) {
+    if (this._canMergeSection(section)) {
+      this._mergeSection(section);
+      return;
+    }
+
+    section = this._isNested ? section : this._wrapNestedSection(section);
+    this._breakAtCursor();
+    this._insertLeafSection(section);
+  }
+
+  // break out of a nested cursor position
+  _breakNestedAtCursor() {
+    assert('Cannot call _breakNestedAtCursor if not nested',
+           this._isNested);
+
+    let parent = this.cursorSection.parent,
+        cursorAtEndOfList = this.cursorPosition.isEqual(parent.tailPosition());
+
+    if (cursorAtEndOfList) {
+      let blank = this.builder.createMarkupSection();
+      this._insertSectionAfter(blank, parent);
+      this.cursorPosition = blank.headPosition();
+    } else {
+      let [pre, blank, post] = this._breakListAtCursor(); // jshint ignore:line
+      this.cursorPosition = blank.headPosition();
+    }
+  }
+
+  _breakListAtCursor() {
+    assert('Cannot _splitParentSection if cursor position is not nested',
+           this._isNested);
+
+    let list     = this.cursorSection.parent,
+        position = this.cursorPosition,
+        blank    = this.builder.createMarkupSection();
+    let [pre, post] = this.postEditor._splitListAtPosition(list, position);
+
+    let collection = this._post.sections,
+        reference  = post;
+    this.postEditor.insertSectionBefore(collection, blank, reference);
+    return [pre, blank, post];
+  }
+
+  _insertSectionAfter(section, parent) {
+    assert('Cannot _insertSectionAfter nested section', !parent.isNested);
+    let reference = parent.next;
+    let collection = this._post.sections;
+    this.postEditor.insertSectionBefore(collection, section, reference);
+  }
+
+  _wrapNestedSection(section) {
+    let tagName = section.parent.tagName;
+    let parent = this.builder.createListSection(tagName);
+    parent.items.append(section.clone());
+    return parent;
+  }
+
+  _mergeSection(section) {
+    assert('Can only merge markerable sections',
+           this._isMarkerable && section.isMarkerable);
+    this._hasInsertedFirstLeafSection = true;
+
+    let markers = section.markers.map(m => m.clone());
+    let position = this.postEditor.insertMarkers(this.cursorPosition, markers);
+
+    this.cursorPosition = position;
+  }
+
+  // Can be called to add a line break when in a nested section or a parent
+  // section.
+  _breakAtCursor() {
+    if (this.cursorSection.isBlank) {
+      return;
+    } else if (this._isMarkerable) {
+      this._breakMarkerableAtCursor();
+    } else {
+      this._breakNonMarkerableAtCursor();
+    }
+  }
+
+  // Inserts a blank section before/after the cursor,
+  // depending on cursor position.
+  _breakNonMarkerableAtCursor() {
+    let collection = this._post.sections,
+        blank = this.builder.createMarkupSection(),
+        reference = this.cursorPosition.isHead() ? this.cursorSection :
+                                                   this.cursorSection.next;
+    this.postEditor.insertSectionBefore(collection, blank, reference);
+    this.cursorPosition = blank.tailPosition();
+  }
+
+  _breakMarkerableAtCursor() {
+    let [pre, post] = // jshint ignore:line
+      this.postEditor.splitSection(this.cursorPosition);
+    this.cursorPosition = pre.tailPosition();
+  }
+
+  _replaceSection(section, newSections) {
+    assert('Cannot replace section that does not have parent.sections',
+           section.parent && section.parent.sections);
+    assert('Must pass enumerable to _replaceSection', !!newSections.forEach);
+
+    let collection = section.parent.sections,
+        reference = section.next;
+    this.postEditor.removeSection(section);
+    newSections.forEach(_newSection => {
+      this.postEditor.insertSectionBefore(collection, _newSection, reference);
+    });
+  }
+
+  _insertLeafSection(section) {
+    assert('Can only _insertLeafSection when cursor is at end of section',
+           this.cursorPosition.isTail());
+
+    this._hasInsertedFirstLeafSection = true;
+    section = section.clone();
+
+    if (this.cursorSection.isBlank) {
+      assert('Cannot insert leaf non-markerable section when cursor is nested',
+             !(section.isMarkerable && this._isNested));
+      this._replaceSection(this.cursorSection, [section]);
+    } else if (this.cursorSection.next && this.cursorSection.next.isBlank) {
+      this._replaceSection(this.cursorSection.next, [section]);
+    } else {
+      let reference = this.cursorSection.next;
+      let collection = this.cursorSection.parent.sections;
+      this.postEditor.insertSectionBefore(collection, section, reference);
+    }
+
+    this.cursorPosition = section.tailPosition();
+  }
+}
+
+export default class Inserter {
+  constructor(postEditor, post) {
+    this.postEditor = postEditor;
+    this.post = post;
+  }
+
+  insert(cursorPosition, newPost) {
+    let visitor = new Visitor(this, cursorPosition);
+    visitor.visit(newPost);
+    return visitor.cursorPosition;
+  }
+}

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -17,6 +17,7 @@ export default class Section extends LinkedItem {
     assert('Cannot create section without type', !!type);
     this.type = type;
     this.isMarkerable = false;
+    this.isNested = false;
   }
 
   set tagName(val) {

--- a/src/js/models/list-item.js
+++ b/src/js/models/list-item.js
@@ -13,6 +13,7 @@ export default class ListItem extends Markerable {
   constructor(tagName, markers=[]) {
     super(LIST_ITEM_TYPE, tagName, markers);
     this.isListItem = true;
+    this.isNested = true;
   }
 
   isValidTagName(normalizedTagName) {

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -3,6 +3,7 @@ import { forEach, contains } from '../utils/array-utils';
 import { LIST_SECTION_TYPE } from './types';
 import Section from './_section';
 import { normalizeTagName } from '../utils/dom-utils';
+import assert from '../utils/assert';
 
 export const VALID_LIST_SECTION_TAGNAMES = [
   'ul', 'ol'
@@ -17,7 +18,11 @@ export default class ListSection extends Section {
     this.isListSection = true;
 
     this.items = new LinkedList({
-      adoptItem: i => i.section = i.parent = this,
+      adoptItem: i => {
+        assert(`Cannot insert non-list-item to list (is: ${i.type})`,
+               i.isListItem);
+        i.section = i.parent = this;
+      },
       freeItem:  i => i.section = i.parent = null
     });
     this.sections = this.items;
@@ -46,7 +51,7 @@ export default class ListSection extends Section {
   }
 
   clone() {
-    let newSection = this.builder.createListSection();
+    let newSection = this.builder.createListSection(this.tagName);
     forEach(this.items, i => newSection.items.append(i.clone()));
     return newSection;
   }

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -1,8 +1,8 @@
 import { MARKER_TYPE } from './types';
-
 import { normalizeTagName } from '../utils/dom-utils';
 import { detect, commonItemLength, forEach, filter } from '../utils/array-utils';
 import LinkedItem from '../utils/linked-item';
+import assert from '../utils/assert';
 
 const Marker = class Marker extends LinkedItem {
   constructor(value='', markups=[]) {
@@ -10,6 +10,7 @@ const Marker = class Marker extends LinkedItem {
     this.value = value;
     this.markups = [];
     this.type = MARKER_TYPE;
+    this.isMarker = true;
     markups.forEach(m => this.addMarkup(m));
   }
 
@@ -114,6 +115,25 @@ const Marker = class Marker extends LinkedItem {
 
     this.markups.forEach(mu => markers.forEach(m => m.addMarkup(mu)));
     return markers;
+  }
+
+  /**
+   * @return {Array} 2 markers either or both of which could be blank
+   */
+  splitAtOffset(offset) {
+    assert('Cannot split a marker at an offset > its length',
+           offset <= this.length);
+    let { value, builder } = this;
+
+    let pre  = builder.createMarker(value.substring(0, offset));
+    let post = builder.createMarker(value.substring(offset));
+
+    this.markups.forEach(markup => {
+      pre.addMarkup(markup);
+      post.addMarkup(markup);
+    });
+
+    return [pre, post];
   }
 
   get openedMarkups() {

--- a/src/js/models/render-tree.js
+++ b/src/js/models/render-tree.js
@@ -33,7 +33,7 @@ export default class RenderTree {
   }
   /**
    * @param {DOMNode} element
-   * Walk up from the element until we find a renderNode element
+   * Walk up from the dom element until we find a renderNode element
    */
   findRenderNodeFromElement(element, conditionFn=()=>true) {
     let renderNode;

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -68,6 +68,14 @@ const Position = class Position {
            this.offset  === position.offset;
   }
 
+  isHead() {
+    return this.isEqual(this.section.headPosition());
+  }
+
+  isTail() {
+    return this.isEqual(this.section.tailPosition());
+  }
+
   move(direction) {
     switch (direction) {
       case DIRECTION.BACKWARD:

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -311,3 +311,30 @@ test('pasting when on the end of a card is blocked', (assert) => {
     ]
   ], 'no paste has occurred');
 });
+
+// see https://github.com/bustlelabs/mobiledoc-kit/issues/249
+test('pasting when replacing a list item works', (assert) => {
+  let mobiledoc = Helpers.mobiledoc.build(
+    ({post, listSection, listItem, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('X')]),
+      listSection('ul', [
+        listItem([marker('Y')])
+      ])
+    ]);
+  });
+
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  assert.hasElement('#editor li:contains(Y)', 'precond: has li with Y');
+
+  Helpers.dom.selectText('X', editorElement);
+  Helpers.dom.triggerCopyEvent(editor);
+
+  Helpers.dom.selectText('Y', editorElement);
+  Helpers.dom.triggerPasteEvent(editor);
+
+  assert.hasElement('#editor li:contains(X)', 'replaces Y with X in li');
+  assert.hasNoElement('#editor li:contains(Y)', 'li with Y is gone');
+});

--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -135,6 +135,7 @@ test('can split list item with <enter>', (assert) => {
 });
 
 test('can hit enter at end of list item to add new item', (assert) => {
+  let done = assert.async();
   createEditorWithListMobiledoc();
 
   const li = $('#editor li:contains(first item)')[0];
@@ -148,13 +149,16 @@ test('can hit enter at end of list item to add new item', (assert) => {
   assert.equal(newLi.text(), '', 'new li has no text');
 
   Helpers.dom.insertText(editor, 'X');
-  assert.hasElement('#editor li:contains(X)', 'text goes in right spot');
+  setTimeout(() => {
+    assert.hasElement('#editor li:contains(X)', 'text goes in right spot');
 
-  const liCount = $('#editor li').length;
-  Helpers.dom.triggerEnter(editor);
-  Helpers.dom.triggerEnter(editor);
+    const liCount = $('#editor li').length;
+    Helpers.dom.triggerEnter(editor);
+    Helpers.dom.triggerEnter(editor);
 
-  assert.equal($('#editor li').length, liCount+2, 'adds two new empty list items');
+    assert.equal($('#editor li').length, liCount+2, 'adds two new empty list items');
+    done();
+  });
 });
 
 test('hitting enter to add list item, deleting to remove it, adding new list item, exiting list and typing', (assert) => {

--- a/tests/helpers/assertions.js
+++ b/tests/helpers/assertions.js
@@ -1,15 +1,123 @@
 /* global QUnit, $ */
 
 import DOMHelper from './dom';
+import mobiledocRenderers from 'mobiledoc-kit/renderers/mobiledoc';
+import {
+  MARKUP_SECTION_TYPE,
+  LIST_SECTION_TYPE,
+  MARKUP_TYPE,
+  MARKER_TYPE,
+  POST_TYPE,
+  LIST_ITEM_TYPE,
+  CARD_TYPE,
+  IMAGE_SECTION_TYPE
+} from 'mobiledoc-kit/models/types';
+
+function comparePostNode(actual, expected, assert, path='root', deepCompare=false) {
+  if (!actual || !expected) {
+    assert.ok(!!actual, `missing actual post node at ${path}`);
+    assert.ok(!!expected, `missing expected post node at ${path}`);
+    return;
+  }
+  if (actual.type !== expected.type) {
+    assert.push(false, actual.type, expected.type, `wrong type at ${path}`);
+  }
+
+  switch (actual.type) {
+    case POST_TYPE:
+      if (actual.sections.length !== expected.sections.length) {
+        assert.equal(actual.sections.length, expected.sections.length,
+                     `wrong sections for post`);
+      }
+      if (deepCompare) {
+        actual.sections.forEach((section, index) => {
+          comparePostNode(section, expected.sections.objectAt(index),
+                          assert, `${path}:${index}`, deepCompare);
+        });
+      }
+      break;
+    case MARKER_TYPE:
+      if (actual.value !== expected.value) {
+        assert.equal(actual.value, expected.value, `wrong value at ${path}`);
+      }
+      if (actual.markups.length !== expected.markups.length) {
+        assert.equal(actual.markups.length, expected.markups.length,
+                     `wrong markups at ${path}`);
+      }
+      if (deepCompare) {
+        actual.markups.forEach((markup, index) => {
+          comparePostNode(markup, expected.markups[index],
+                          assert, `${path}:${index}`, deepCompare);
+        });
+      }
+      break;
+    case MARKUP_SECTION_TYPE:
+    case LIST_ITEM_TYPE:
+      if (actual.tagName !== expected.tagName) {
+        assert.equal(actual.tagName, expected.tagName, `wrong tagName at ${path}`);
+      }
+      if (actual.markers.length !== expected.markers.length) {
+        assert.equal(actual.markers.length, expected.markers.length,
+                     `wrong markers at ${path}`);
+      }
+      if (deepCompare) {
+        actual.markers.forEach((marker, index) => {
+          comparePostNode(marker, expected.markers.objectAt(index),
+                          assert, `${path}:${index}`, deepCompare);
+        });
+      }
+      break;
+    case CARD_TYPE:
+      if (actual.name !== expected.name) {
+        assert.equal(actual.name, expected.name, `wrong card name at ${path}`);
+      }
+      if (!QUnit.equiv(actual.payload, expected.payload)) {
+        assert.deepEqual(actual.payload, expected.payload,
+                         `wrong card payload at ${path}`);
+      }
+      break;
+    case LIST_SECTION_TYPE:
+      if (actual.items.length !== expected.items.length) {
+        assert.equal(actual.items.length, expected.items.length,
+                     `wrong items at ${path}`);
+      }
+      if (deepCompare) {
+        actual.items.forEach((item, index) => {
+          comparePostNode(item, expected.items.objectAt(index),
+                          assert, `${path}:${index}`, deepCompare);
+        });
+      }
+      break;
+    case IMAGE_SECTION_TYPE:
+      if (actual.src !== expected.src) {
+        assert.equal(actual.src, expected.src, `wrong image src at ${path}`);
+      }
+      break;
+    case MARKUP_TYPE:
+      if (actual.tagName !== expected.tagName) {
+        assert.equal(actual.tagName, expected.tagName,
+                     `wrong tagName at ${path}`);
+      }
+      if (!QUnit.equiv(actual.attributes, expected.attributes)) {
+        assert.deepEqual(actual.attributes, expected.attributes,
+                         `wrong attributes at ${path}`);
+      }
+      break;
+    default:
+      throw new Error('wrong type :' + actual.type);
+  }
+}
 
 export default function registerAssertions() {
-  QUnit.assert.hasElement = function(selector, message=`hasElement "${selector}"`) {
+  QUnit.assert.hasElement = function(selector,
+                                     message=`hasElement "${selector}"`) {
     let found = $(selector);
     this.push(found.length > 0, found.length, selector, message);
     return found;
   };
 
-  QUnit.assert.hasNoElement = function(selector, message=`hasNoElement "${selector}"`) {
+  QUnit.assert.hasNoElement = function(selector,
+                                       message=`hasNoElement "${selector}"`) {
     let found = $(selector);
     this.push(found.length === 0, found.length, selector, message);
     return found;
@@ -23,7 +131,69 @@ export default function registerAssertions() {
               message);
   };
 
-  QUnit.assert.inArray = function(element, array, message=`has "${element}" in "${array}"`) {
+  QUnit.assert.inArray = function(element, array,
+                                  message=`has "${element}" in "${array}"`) {
     QUnit.assert.ok(array.indexOf(element) !== -1, message);
   };
+
+  QUnit.assert.postIsSimilar = function(post, expected, postName='post') {
+    comparePostNode(post, expected, this, postName, true);
+    let mobiledoc         = mobiledocRenderers.render(post),
+        expectedMobiledoc = mobiledocRenderers.render(expected);
+    this.deepEqual(mobiledoc, expectedMobiledoc,
+                   `${postName} is similar to expected`);
+  };
+
+  QUnit.assert.renderTreeIsEqual = function(renderTree, expectedPost) {
+    if (renderTree.rootNode.isDirty) {
+      this.ok(false, 'renderTree is dirty');
+      return;
+    }
+
+    expectedPost.sections.forEach((section, index) => {
+      let renderNode = renderTree.rootNode.childNodes.objectAt(index);
+      let path = `post:${index}`;
+
+      let compareChildren = (parentPostNode, parentRenderNode, path) => {
+        let children = parentPostNode.markers ||
+                       parentPostNode.items ||
+                       [];
+
+        if (children.length !== parentRenderNode.childNodes.length) {
+          this.equal(parentRenderNode.childNodes.length, children.length,
+                     `wrong child render nodes at ${path}`);
+          return;
+        }
+
+        children.forEach((child, index) => {
+          let renderNode = parentRenderNode.childNodes.objectAt(index);
+
+          comparePostNode(child, renderNode && renderNode.postNode,
+                          this, `${path}:${index}`, false);
+          compareChildren(child, renderNode, `${path}:${index}`);
+        });
+      };
+
+      comparePostNode(section, renderNode.postNode, this, path, false);
+      compareChildren(section, renderNode, path);
+    });
+
+    this.ok(true, 'renderNode is similar');
+  };
+
+  QUnit.assert.positionIsEqual = function(position, expected,
+                                          message=`position is equal`) {
+    if (position.section !== expected.section) {
+      this.push(false,
+                `${position.section.type}:${position.section.tagName}`,
+                `${expected.section.type}:${expected.section.tagName}`,
+               `incorrect position section`);
+    } else if (position.offset !== expected.offset) {
+      this.push(false, position.offset, expected.offset,
+                `incorrect position offset`);
+    } else {
+      this.push(true, position, expected, message);
+    }
+  };
+
 }

--- a/tests/unit/editor/post/insert-post-test.js
+++ b/tests/unit/editor/post/insert-post-test.js
@@ -1,0 +1,995 @@
+import PostEditor from 'mobiledoc-kit/editor/post';
+import { Editor } from 'mobiledoc-kit';
+import Helpers from '../../../test-helpers';
+import Position from 'mobiledoc-kit/utils/cursor/position';
+
+const { module, test } = Helpers;
+
+let editor, editorElement, postEditor, renderedRange;
+// see https://github.com/bustlelabs/mobiledoc-kit/issues/259
+module('Unit: PostEditor: #insertPost', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+
+  afterEach() {
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
+  }
+});
+
+function buildEditorWithMobiledoc(builderFn) {
+  let mobiledoc = Helpers.mobiledoc.build(builderFn);
+  let unknownCardHandler = () => {};
+  editor = new Editor({mobiledoc, unknownCardHandler});
+  editor.render(editorElement);
+  editor.renderRange = function() {
+    renderedRange = this.range;
+  };
+  return editor;
+}
+
+test('in blank section replaces it', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('abc')])])]);
+    expected = post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection}) => {
+    return post([markupSection()]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  assert.positionIsEqual(renderedRange.head,
+                         editor.post.sections.head.items.tail.tailPosition(),
+                        'cursor at end of pasted content');
+});
+
+test('in non-markerable at start inserts before', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([markupSection('p', [marker('abc')])]);
+    expected = post([
+      markupSection('p', [marker('abc')]),
+      cardSection('my-card', {foo:'bar'})
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, cardSection}) => {
+    return post([cardSection('my-card', {foo:'bar'})]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                        'cursor at end of pasted');
+});
+
+test('in non-markerable at end inserts after', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([markupSection('p', [marker('abc')])]);
+    expected = post([
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('abc')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, cardSection}) => {
+    return post([cardSection('my-card', {foo:'bar'})]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.tail;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                        'cursor at end of pasted');
+});
+
+test('in non-nested markerable at start and paste is single non-markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([cardSection('my-card', {foo:'bar'})]);
+    expected = post([
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('abc')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at end and paste is single non-markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([cardSection('my-card', {foo:'bar'})]);
+    expected = post([
+      markupSection('p', [marker('abc')]),
+      cardSection('my-card', {foo:'bar'})
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.tail; // card
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at middle and paste is single non-markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([cardSection('my-card', {foo:'bar'})]);
+    expected = post([
+      markupSection('p', [marker('ab')]),
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('c')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = new Position(editor.post.sections.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at start and paste starts with non-markerable and ends with markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('def')])
+    ]);
+    expected = post([
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('abc')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at middle and paste starts with non-markerable and ends with markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('def')])
+    ]);
+    expected = post([
+      markupSection('p', [marker('ab')]),
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('c')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = new Position(editor.post.sections.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(2);
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, 'def'.length),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at end and paste starts with non-markerable and ends with markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('def')])
+    ]);
+    expected = post([
+      markupSection('p', [marker('abc')]),
+      cardSection('my-card', {foo:'bar'}),
+      markupSection('p', [marker('def')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.tail;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, 'def'.length),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at start and paste is single non-nested markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([markupSection('p', [marker('123')])]);
+    expected = post([markupSection('p', [marker('123abc')])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, '123'.length),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at middle and paste is single non-nested markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([markupSection('p', [marker('123')])]);
+    expected = post([markupSection('p', [marker('ab123c')])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = new Position(editor.post.sections.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, 'ab123'.length),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at end and paste is single non-nested markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(({post, cardSection, markupSection, marker}) => {
+    toInsert = post([markupSection('p', [marker('123')])]);
+    expected = post([markupSection('p', [marker('abc123')])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at start and paste is list with 1 item and no more sections', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')])])]);
+    expected = post([markupSection('p', [marker('123abc')])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, '123'.length),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at middle and paste is list with 1 item and no more sections', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')])])]);
+    expected = post([markupSection('p', [marker('ab123c')])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = new Position(editor.post.sections.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, 'ab123'.length),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at end and paste is list with 1 item and no more sections', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')])])]);
+    expected = post([markupSection('p', [marker('abc123')])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at start and paste is list with 1 item and has more sections', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      listSection('ul', [listItem([marker('123')])]),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('ghi')])
+    ]);
+    expected = post([
+      markupSection('p', [marker('123')]),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('ghi')]),
+      markupSection('p', [marker('abc')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(2);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at middle and paste is list with 1 item and has more sections', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      listSection('ul', [listItem([marker('123')])]),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('ghi')])
+    ]);
+    expected = post([
+      markupSection('p', [marker('ab123')]),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('ghi')]),
+      markupSection('p', [marker('c')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = new Position(editor.post.sections.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(2);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at end and paste is list with 1 item and has more sections', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      listSection('ul', [listItem([marker('123')])]),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('ghi')])
+    ]);
+    expected = post([
+      markupSection('p', [marker('abc123')]),
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('ghi')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.tail;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at start and paste is only list with > 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      listSection('ul', [
+        listItem([marker('123')]),
+        listItem([marker('456')])
+      ])
+    ]);
+    expected = post([
+      markupSection('p', [marker('123')]),
+      listSection('ul', [listItem([marker('456')])]),
+      markupSection('p', [marker('abc')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at end and paste is only list with > 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      listSection('ul', [
+        listItem([marker('123')]),
+        listItem([marker('456')])
+      ])
+    ]);
+    expected = post([
+      markupSection('p', [marker('abc123')]),
+      listSection('ul', [listItem([marker('456')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.tail;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in non-nested markerable at middle and paste is only list with > 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      listSection('ul', [
+        listItem([marker('123')]),
+        listItem([marker('456')])
+      ])
+    ]);
+    expected = post([
+      markupSection('p', [marker('ab123')]),
+      listSection('ul', [listItem([marker('456')])]),
+      markupSection('p', [marker('c')])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let position = new Position(editor.post.sections.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in nested markerable at start and paste is single non-nested markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([markupSection('p', [marker('123')])]);
+    expected = post([
+      listSection('ul', [listItem([marker('123abc')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, '123'.length),
+                         'cursor at end of pasted content');
+});
+
+test('in nested markerable at end and paste is single non-nested markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([markupSection('p', [marker('123')])]);
+    expected = post([
+      listSection('ul', [listItem([marker('abc123')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.head;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted content');
+});
+
+test('in nested markerable at middle and paste is single non-nested markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([markupSection('p', [marker('123')])]);
+    expected = post([
+      listSection('ul', [listItem([marker('ab123c')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = new Position(editor.post.sections.head.items.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, 'ab123'.length),
+                         'cursor at end of pasted content');
+});
+
+test('in nested markerable at start and paste is list with 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')])])]);
+    expected = post([listSection('ul', [listItem([marker('123abc')])])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, '123'.length),
+                         'cursor at end of pasted content');
+});
+
+test('in nested markerable at end and paste is list with 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')])])]);
+    expected = post([listSection('ul', [listItem([marker('abc123')])])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.head;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted content');
+});
+
+test('in nested markerable at middle and paste is list with 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')])])]);
+    expected = post([listSection('ul', [listItem([marker('ab123c')])])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = new Position(editor.post.sections.head.items.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.head;
+  assert.positionIsEqual(renderedRange.head,
+                         new Position(expectedSection, 'ab123'.length),
+                         'cursor at end of pasted content');
+});
+
+test('in nested markerable at start and paste is list with > 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')]), listItem([marker('456')])])]);
+    expected = post([listSection('ul', [
+      listItem([marker('123')]), listItem([marker('456')]), listItem([marker('abc')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in nested markerable at end and paste is list with > 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')]), listItem([marker('456')])])]);
+    expected = post([listSection('ul', [listItem([marker('abc123')]), listItem([marker('456')])])]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  // FIXME is this the correct expected position?
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.tail;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in nested markerable at middle and paste is list with > 1 item', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([listSection('ul', [listItem([marker('123')]), listItem([marker('456')])])]);
+    expected = post([listSection('ul', [
+      listItem([marker('ab123')]), listItem([marker('456')]), listItem([marker('c')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = new Position(editor.post.sections.head.items.head, 'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.head.items.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in nested markerable at start and paste is list with 1 item and more sections', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      listSection('ul', [listItem([marker('123')])]),
+      markupSection('p', [marker('456')])
+    ]);
+    expected = post([
+      listSection('ul', [listItem([marker('123')])]),
+      markupSection('p', [marker('456')]),
+      listSection('ul', [listItem([marker('abc')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in blank nested markerable (1 item in list) and paste is non-markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, listSection, listItem}) => {
+    toInsert = post([
+      cardSection('the-card', {foo: 'bar'})
+    ]);
+    expected = post([
+      listSection('ul', [listItem()]),
+      cardSection('the-card', {foo: 'bar'})
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem}) => {
+    return post([listSection('ul', [listItem()])]);
+  });
+
+  let position = editor.post.sections.head.headPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  assert.postIsSimilar(editor.post, expected);
+  let expectedSection = editor.post.sections.tail;
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in nested markerable at end with multiple items and paste is non-markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      cardSection('the-card', {foo: 'bar'})
+    ]);
+    expected = post([
+      listSection('ul', [listItem([marker('123')])]),
+      cardSection('the-card', {foo: 'bar'}),
+      listSection('ul', [listItem([marker('abc')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('123')]), listItem([marker('abc')])])]);
+  });
+
+  let position = editor.post.sections.head.items.head.tailPosition();
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.postIsSimilar(editor.post, expected);
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  let expectedSection = editor.post.sections.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});
+
+test('in nested markerable at middle with multiple items and paste is non-markerable', (assert) => {
+  let toInsert, expected;
+  Helpers.postAbstract.build(
+    ({post, cardSection, listSection, listItem, marker}) => {
+    toInsert = post([
+      cardSection('the-card', {foo: 'bar'})
+    ]);
+    expected = post([
+      listSection('ul', [listItem([marker('ab')])]),
+      cardSection('the-card', {foo: 'bar'}),
+      listSection('ul', [listItem([marker('c')]), listItem([marker('def')])])
+    ]);
+  });
+
+  editor = buildEditorWithMobiledoc(({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')]), listItem([marker('def')])])]);
+  });
+
+  let position = new Position(editor.post.sections.head.items.head,
+                              'ab'.length);
+  postEditor = new PostEditor(editor);
+  postEditor.insertPost(position, toInsert);
+  postEditor.complete();
+
+  assert.postIsSimilar(editor.post, expected);
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+  let expectedSection = editor.post.sections.objectAt(1);
+  assert.positionIsEqual(renderedRange.head,
+                         expectedSection.tailPosition(),
+                         'cursor at end of pasted');
+});

--- a/tests/unit/models/list-section-test.js
+++ b/tests/unit/models/list-section-test.js
@@ -1,0 +1,24 @@
+import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
+import TestHelpers from '../../test-helpers';
+
+const {module, test} = TestHelpers;
+
+let builder;
+module('Unit: List Section', {
+  beforeEach() {
+    builder = new PostNodeBuilder();
+  },
+  afterEach() {
+    builder = null;
+  }
+});
+
+test('cloning a list section creates the same type of list section', (assert) => {
+  let item = builder.createListItem([builder.createMarker('abc')]);
+  let list = builder.createListSection('ol', [item]);
+  let cloned = list.clone();
+
+  assert.equal(list.tagName, cloned.tagName);
+  assert.equal(list.items.length, cloned.items.length);
+  assert.equal(list.items.head.text, cloned.items.head.text);
+});

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -456,3 +456,86 @@ test('#cloneRange copies card sections', (assert) => {
 
   assert.deepEqual(mobiledoc, expectedMobiledoc);
 });
+
+test('#cloneRange when range starts and ends in a list item', (assert) => {
+  let buildPost = Helpers.postAbstract.build,
+      buildMobiledoc = Helpers.mobiledoc.build;
+
+  let post = buildPost(
+    ({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('abc')])])]);
+  });
+
+  let range = Range.create(post.sections.head.items.head, 0,
+                           post.sections.head.items.head, 'ab'.length);
+
+  let mobiledoc = post.cloneRange(range);
+  let expected = buildMobiledoc(
+    ({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [listItem([marker('ab')])])]);
+  });
+
+  assert.deepEqual(mobiledoc, expected);
+});
+
+test('#cloneRange when range contains multiple list items', (assert) => {
+  let buildPost = Helpers.postAbstract.build,
+      buildMobiledoc = Helpers.mobiledoc.build;
+
+  let post = buildPost(
+    ({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [
+      listItem([marker('abc')]),
+      listItem([marker('def')]),
+      listItem([marker('ghi')])
+    ])]);
+  });
+
+  let range = Range.create(post.sections.head.items.head, 'ab'.length,
+                           post.sections.head.items.tail, 'gh'.length);
+
+  let mobiledoc = post.cloneRange(range);
+  let expected = buildMobiledoc(
+    ({post, listSection, listItem, marker}) => {
+    return post([listSection('ul', [
+      listItem([marker('c')]),
+      listItem([marker('def')]),
+      listItem([marker('gh')])
+    ])]);
+  });
+
+  assert.deepEqual(mobiledoc, expected);
+});
+
+test('#cloneRange when range contains multiple list items and more sections', (assert) => {
+  let buildPost = Helpers.postAbstract.build,
+      buildMobiledoc = Helpers.mobiledoc.build;
+
+  let post = buildPost(
+    ({post, listSection, listItem, markupSection, marker}) => {
+    return post([listSection('ul', [
+      listItem([marker('abc')]),
+      listItem([marker('def')]),
+      listItem([marker('ghi')])
+    ]), markupSection('p', [
+      marker('123')
+    ])]);
+  });
+
+  let range = Range.create(post.sections.head.items.head, 'ab'.length,
+                           post.sections.tail, '12'.length);
+
+  let mobiledoc = post.cloneRange(range);
+  let expected = buildMobiledoc(
+    ({post, listSection, listItem, markupSection, marker}) => {
+    return post([listSection('ul', [
+      listItem([marker('c')]),
+      listItem([marker('def')]),
+      listItem([marker('ghi')])
+    ]), markupSection('p', [
+      marker('12')
+    ])]);
+  });
+
+  assert.deepEqual(mobiledoc, expected);
+});


### PR DESCRIPTION
Ready to start getting feedback on this. There are some todos and fixmes I intend to address before this should be merged, though.

  * refactor postEditor#insertPost to handle a larger number of situations
  * fix bug in post#cloneRange when range starts in list item
  * add assert.isPostSimilar, assert.isRenderTreeEqual, assert.isPositionEqual
  * add test for ListSection#clone

Fix #249 #259