### PR TITLE
Add text parser, use it for handling pasted text

### DIFF
--- a/src/js/parsers/html.js
+++ b/src/js/parsers/html.js
@@ -9,6 +9,10 @@ export default class HTMLParser {
     this.options = options;
   }
 
+  /**
+   * @param {String} html to parse
+   * @return {Post} A post abstract
+   */
   parse(html) {
     let dom = parseHTML(html);
     let parser = new DOMParser(this.builder, this.options);

--- a/src/js/parsers/text.js
+++ b/src/js/parsers/text.js
@@ -1,0 +1,95 @@
+import assert from 'mobiledoc-kit/utils/assert';
+import {
+  MARKUP_SECTION_TYPE,
+  LIST_SECTION_TYPE
+} from 'mobiledoc-kit/models/types';
+import {
+  DEFAULT_TAG_NAME as DEFAULT_MARKUP_SECTION_TAG_NAME
+} from 'mobiledoc-kit/models/markup-section';
+
+const UL_LI_REGEX = /^\* (.*)$/;
+const OL_LI_REGEX = /^\d\.? (.*)$/;
+const CR = '\r';
+const LF = '\n';
+const CR_REGEX = new RegExp(CR, 'g');
+const CR_LF_REGEX = new RegExp(CR+LF, 'g');
+
+export const SECTION_BREAK = LF;
+
+function normalizeLindEndings(text) {
+  return text.replace(CR_LF_REGEX, LF)
+             .replace(CR_REGEX, LF);
+}
+
+export default class TextParser {
+  constructor(builder, options) {
+    this.builder = builder;
+    this.options = options;
+
+    this.post = this.builder.createPost();
+    this.prevSection = null;
+  }
+
+  /**
+   * @param {String} text to parse
+   * @return {Post} a post abstract
+   */
+  parse(text) {
+    text = normalizeLindEndings(text);
+    text.split(SECTION_BREAK).forEach(text => {
+      let section = this._parseSection(text);
+      this._appendSection(section);
+    });
+
+    return this.post;
+  }
+
+  _parseSection(text) {
+    let tagName = DEFAULT_MARKUP_SECTION_TAG_NAME,
+        type    = MARKUP_SECTION_TYPE,
+        section;
+
+    if (UL_LI_REGEX.test(text)) {
+      tagName = 'ul';
+      type = LIST_SECTION_TYPE;
+      text = text.match(UL_LI_REGEX)[1];
+    } else if (OL_LI_REGEX.test(text)) {
+      tagName = 'ol';
+      type = LIST_SECTION_TYPE;
+      text = text.match(OL_LI_REGEX)[1];
+    }
+
+    let markers = [this.builder.createMarker(text)];
+
+    switch (type) {
+      case LIST_SECTION_TYPE:
+        let item = this.builder.createListItem(markers);
+        let list = this.builder.createListSection(tagName, [item]);
+        section = list;
+        break;
+      case MARKUP_SECTION_TYPE:
+        section = this.builder.createMarkupSection(tagName, markers);
+        break;
+      default:
+        assert(`Unknown type encountered ${type}`, false);
+    }
+
+    return section;
+  }
+
+  _appendSection(section) {
+    let isSameListSection =
+      section.isListSection &&
+      this.prevSection && this.prevSection.isListSection &&
+      this.prevSection.tagName === section.tagName;
+
+    if (isSameListSection) {
+      section.items.forEach(item => {
+        this.prevSection.items.append(item.clone());
+      });
+    } else {
+      this.post.sections.insertAfter(section, this.prevSection);
+      this.prevSection = section;
+    }
+  }
+}

--- a/src/js/utils/paste-utils.js
+++ b/src/js/utils/paste-utils.js
@@ -1,9 +1,39 @@
 /* global JSON */
 import mobiledocParsers from '../parsers/mobiledoc';
 import HTMLParser from '../parsers/html';
+import TextParser from '../parsers/text';
 import HTMLRenderer from 'mobiledoc-html-renderer';
 import TextRenderer from 'mobiledoc-text-renderer';
 
+const MOBILEDOC_REGEX = new RegExp(/data\-mobiledoc='(.*?)'>/);
+export const MIME_TEXT_PLAIN = 'text/plain';
+export const MIME_TEXT_HTML = 'text/html';
+
+function parsePostFromHTML(html, builder, plugins) {
+  let post;
+
+  if (MOBILEDOC_REGEX.test(html)) {
+    let mobiledocString = html.match(MOBILEDOC_REGEX)[1];
+    let mobiledoc = JSON.parse(mobiledocString);
+    post = mobiledocParsers.parse(builder, mobiledoc);
+  } else {
+    post = new HTMLParser(builder, {plugins}).parse(html);
+  }
+
+  return post;
+}
+
+function parsePostFromText(text, builder, plugins) {
+  let parser = new TextParser(builder, {plugins});
+  let post = parser.parse(text);
+  return post;
+}
+
+/**
+ * @param {Event} copyEvent
+ * @param {Editor}
+ * @return null
+ */
 export function setClipboardCopyData(copyEvent, editor) {
   const { cursor, post } = editor;
   const { clipboardData } = copyEvent;
@@ -12,35 +42,33 @@ export function setClipboardCopyData(copyEvent, editor) {
   const mobiledoc = post.cloneRange(range);
 
   let unknownCardHandler = () => {}; // ignore unknown cards
-  let {result: innerHTML } = new HTMLRenderer({unknownCardHandler})
-                                     .render(mobiledoc);
+  let {result: innerHTML } =
+    new HTMLRenderer({unknownCardHandler}).render(mobiledoc);
 
   const html =
     `<div data-mobiledoc='${JSON.stringify(mobiledoc)}'>${innerHTML}</div>`;
-  const {result: plain} = new TextRenderer({unknownCardHandler})
-                      .render(mobiledoc);
+  const {result: plain} =
+    new TextRenderer({unknownCardHandler}).render(mobiledoc);
 
-  clipboardData.setData('text/plain', plain);
-  clipboardData.setData('text/html', html);
+  clipboardData.setData(MIME_TEXT_PLAIN, plain);
+  clipboardData.setData(MIME_TEXT_HTML, html);
 }
 
+/**
+ * @param {Event} pasteEvent
+ * @param {PostNodeBuilder} builder
+ * @param {Array} plugins parser plugins
+ * @return {Post}
+ */
 export function parsePostFromPaste(pasteEvent, builder, plugins=[]) {
-  let mobiledoc, post;
-  const mobiledocRegex = new RegExp(/data\-mobiledoc='(.*?)'>/);
+  let post;
+  let html = pasteEvent.clipboardData.getData(MIME_TEXT_HTML);
 
-  let html = pasteEvent.clipboardData.getData('text/html');
-
-  // Fallback to 'text/plain'
-  if (!html || html.length === 0) {
-    html = pasteEvent.clipboardData.getData('text/plain');
-  }
-
-  if (mobiledocRegex.test(html)) {
-    let mobiledocString = html.match(mobiledocRegex)[1];
-    mobiledoc = JSON.parse(mobiledocString);
-    post = mobiledocParsers.parse(builder, mobiledoc);
+  if (!html || html.length === 0) { // Fallback to 'text/plain'
+    let text = pasteEvent.clipboardData.getData(MIME_TEXT_PLAIN);
+    post = parsePostFromText(text, builder, plugins);
   } else {
-    post = new HTMLParser(builder, {plugins}).parse(html);
+    post = parsePostFromHTML(html, builder, plugins);
   }
 
   return post;

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -298,6 +298,12 @@ function setCopyData(type, value) {
   lastCopyData[type] = value;
 }
 
+function clearCopyData() {
+  Object.keys(lastCopyData).forEach(key => {
+    delete lastCopyData[key];
+  });
+}
+
 function fromHTML(html) {
   html = $.trim(html);
   let div = document.createElement('div');
@@ -327,6 +333,7 @@ const DOMHelper = {
   triggerPasteEvent,
   getCopyData,
   setCopyData,
+  clearCopyData,
   createMockEvent
 };
 

--- a/tests/unit/parsers/text-test.js
+++ b/tests/unit/parsers/text-test.js
@@ -1,0 +1,152 @@
+import TextParser from 'mobiledoc-kit/parsers/text';
+import { SECTION_BREAK } from 'mobiledoc-kit/parsers/text';
+import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
+import Helpers from '../../test-helpers';
+
+const {module, test} = Helpers;
+
+let editorElement, builder, parser, editor;
+
+module('Unit: Parser: TextParser', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+    builder = new PostNodeBuilder();
+    parser = new TextParser(builder);
+  },
+  afterEach() {
+    builder = null;
+    parser = null;
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
+  }
+});
+
+test('#parse returns a markup section when given single line of text', (assert) => {
+  let text = 'some text';
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('some text')])]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse returns multiple markup sections when given multiple lines', (assert) => {
+  let text = ['first', 'second', 'third'].join(SECTION_BREAK);
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('first')]),
+      markupSection('p', [marker('second')]),
+      markupSection('p', [marker('third')])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse returns multiple sections when lines are separated by CR+LF', (assert) => {
+  let text = ['first', 'second', 'third'].join('\r\n');
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('first')]),
+      markupSection('p', [marker('second')]),
+      markupSection('p', [marker('third')])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse returns multiple sections when lines are separated by CR', (assert) => {
+  let text = ['first', 'second', 'third'].join('\r');
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('first')]),
+      markupSection('p', [marker('second')]),
+      markupSection('p', [marker('third')])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse returns list section when text starts with "*"', (assert) => {
+  let text = '* a list item';
+  
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(({post, listSection, listItem, marker}) => {
+    return post([
+      listSection('ul', [listItem([marker('a list item')])])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse returns list section with multiple items when text starts with "*"', (assert) => {
+  let text = ['* first', '* second'].join(SECTION_BREAK);
+  
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(({post, listSection, listItem, marker}) => {
+    return post([
+      listSection('ul', [
+        listItem([marker('first')]),
+        listItem([marker('second')])
+      ])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse returns list sections separated by markup sections', (assert) => {
+  let text = ['* first list', 'middle section', '* second list'].join(SECTION_BREAK);
+  
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(
+    ({post, listSection, listItem, markupSection, marker}) => {
+    return post([
+      listSection('ul', [
+        listItem([marker('first list')])
+      ]),
+      markupSection('p', [marker('middle section')]),
+      listSection('ul', [
+        listItem([marker('second list')])
+      ])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse returns ordered list items', (assert) => {
+  let text = '1. first list';
+  
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(
+    ({post, listSection, listItem, markupSection, marker}) => {
+    return post([listSection('ol', [listItem([marker('first list')])])]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});
+
+test('#parse can have ordered and unordered lists together', (assert) => {
+  let text = ['1. ordered list', '* unordered list'].join(SECTION_BREAK);
+  
+  let post = parser.parse(text);
+  let expected = Helpers.postAbstract.build(
+    ({post, listSection, listItem, markupSection, marker}) => {
+    return post([
+      listSection('ol', [listItem([marker('ordered list')])]),
+      listSection('ul', [listItem([marker('unordered list')])])
+    ]);
+  });
+
+  assert.postIsSimilar(post, expected);
+});


### PR DESCRIPTION
The text parser recognizes multiple sections for text separated by
line breaks and will parse lists when lines of text start with "*"
(unordered) or `"<number>."` (ordered).

fixes #263 

@YoranBrondsema Any feedback you have would be welcome.