### PR TITLE
marker#deleteValueAtOffset detects if the character is outside the BMP

### DIFF
--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -515,8 +515,8 @@ class PostEditor {
 
     const offsetToDeleteAt = markerOffset - 1;
 
-    marker.deleteValueAtOffset(offsetToDeleteAt);
-    nextPosition.offset -= 1;
+    let lengthChange = marker.deleteValueAtOffset(offsetToDeleteAt);
+    nextPosition.offset -= lengthChange;
     this._markDirty(marker);
 
     return nextPosition;

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -268,6 +268,40 @@ test('keystroke of delete removes that character', (assert) => {
                    'cursor is at start of new text node');
 });
 
+test('keystroke of delete removes emoji character', (assert) => {
+  let monkey = 'monkey🙈';
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker(monkey)])]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  let textNode = editorElement.firstChild. // section
+                               firstChild; // marker 
+  assert.equal(textNode.textContent, monkey, 'precond - correct text');
+
+  Helpers.dom.moveCursorTo(textNode, monkey.length);
+  Helpers.dom.triggerDelete(editor);
+
+  assert.equal($('#editor p:eq(0)').text(), 'monkey', 'deletes the emoji');
+});
+
+test('keystroke of forward delete removes emoji character', (assert) => {
+  let monkey = 'monkey🙈';
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker(monkey)])]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  let textNode = editorElement.firstChild. // section
+                               firstChild; // marker 
+  assert.equal(textNode.textContent, monkey, 'precond - correct text');
+
+  Helpers.dom.moveCursorTo(textNode, 'monkey'.length);
+  Helpers.dom.triggerForwardDelete(editor);
+
+  assert.equal($('#editor p:eq(0)').text(), 'monkey', 'deletes the emoji');
+});
+
 test('keystroke of delete when cursor is at beginning of marker removes character from previous marker', (assert) => {
   editor = new Editor({mobiledoc: mobileDocWith2Markers});
   editor.render(editorElement);

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -12,24 +12,6 @@ module('Unit: Marker', {
   }
 });
 
-test('a marker can truncated from an offset', (assert) => {
-  const m1 = builder.createMarker('hi there!');
-
-  const offset = 5;
-  m1.truncateFrom(offset);
-
-  assert.equal(m1.value, 'hi th');
-});
-
-test('a marker can truncated to an offset', (assert) => {
-  const m1 = builder.createMarker('hi there!');
-
-  const offset = 5;
-  m1.truncateTo(offset);
-
-  assert.equal(m1.value, 'ere!');
-});
-
 test('a marker can have a markup applied to it', (assert) => {
   const m1 = builder.createMarker('hi there!');
   m1.addMarkup(builder.createMarkup('b'));
@@ -123,4 +105,18 @@ test('#clone a marker', (assert) => {
   assert.equal(marker.builder, cloned.builder, 'builder is present');
   assert.equal(marker.value, cloned.value, 'value is present');
   assert.equal(marker.markups.length, cloned.markups.length, 'markup length is the same');
+});
+
+// https://github.com/bustlelabs/mobiledoc-kit/issues/274
+test('#deleteValueAtOffset handles emoji', (assert) => {
+  let str = 'monkey 🙈';
+  assert.equal(str.length, 'monkey '.length + 2,
+               'string length reports monkey emoji as length 2');
+  let marker = builder.createMarker(str);
+  marker.deleteValueAtOffset(str.length - 1);
+  assert.equal(marker.value, 'monkey ', 'deletes correctly from low surrogate');
+
+  marker = builder.createMarker(str);
+  marker.deleteValueAtOffset(str.length - 2);
+  assert.equal(marker.value, 'monkey ', 'deletes correctly from high surrogate');
 });


### PR DESCRIPTION

  * [x] acceptance tests for forward- and backward-deleting emoji
  * [x] audit the code for other places that may be affected

There remain some potential places where markers can still be affected by multi-code-point characters. Anywhere in `models/marker.js` that uses the native string-mutation methods (`substr`, e.g.) on `this.value` are affected, but `deleteValueAtOffset` is the only one that will typically trip on this. The other methods will normally be dealing with selections read from the DOM and browsers should not allow a user to select 1/2 of an emoji.

A more comprehensive fix is to write a set of UCS-2 safe string mutation functions and replace every use of built-in string mutation functions in `models/marker.js` with those.

fixes #274