### PR TITLE
Blur element focus on destroy, add null/blank demos

### DIFF
--- a/demo/app/mobiledocs/index.js
+++ b/demo/app/mobiledocs/index.js
@@ -18,6 +18,8 @@ export default {
       []
     ]
   },
+  'null': null,
+  blank: '',
   inputCard: {
     version: '0.2.0',
     sections: [

--- a/demo/app/templates/index.hbs
+++ b/demo/app/templates/index.hbs
@@ -20,6 +20,8 @@
         <option disabled>Load a new Mobiledoc</option>
         <option value='simple'>Simple text content</option>
         <option value='empty'>Empty mobiledoc</option>
+        <option value='null'>Null mobiledoc</option>
+        <option value='blank'>Blank string</option>
         <option value='simpleList'>List example</option>
         <option value='simpleCard'>Simple Card</option>
         <option value='imageCard'>Image Card</option>

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -439,6 +439,7 @@ class Editor {
     this._isDestroyed = true;
     if (this.cursor.hasCursor()) {
       this.cursor.clearSelection();
+      this.element.blur();
     }
     this.removeMutationObserver();
     this._mutationObserver = null;


### PR DESCRIPTION
References https://github.com/bustlelabs/ember-mobiledoc-editor/issues/42#issuecomment-168214682

On destroy the element was not blurred, meaning a subsequent editor attached to that node would need to handle keystrokes on the editor element (and no cursor was visible). Instead destroy should remove the focus.

Also add some new demos to test null and blank mobiledocs with ember-mobiledoc-editor.