### PR TITLE
Remove content-kit-utils, move mobiledoc renderers to dependencies

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -7,7 +7,6 @@ var styles = require('./broccoli/styles');
 var jquery = require('./broccoli/jquery');
 
 var vendoredModules = [
-  {name: 'content-kit-utils', options: {libDirName: 'src'}},
   {name: 'mobiledoc-html-renderer'},
   {name: 'mobiledoc-text-renderer'}
 ];

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "Matthew Beale <matt.beale@madhatted.com> (http://madhatted.com/)"
   ],
   "license": "MIT",
+  "dependencies": {
+    "mobiledoc-html-renderer": "^0.2.0",
+    "mobiledoc-text-renderer": "^0.2.0"
+  },
   "devDependencies": {
     "broccoli": "^0.16.3",
     "broccoli-funnel": "^1.0.1",
@@ -39,11 +43,8 @@
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-multi-builder": "^0.2.8",
     "broccoli-test-builder": "^0.2.0",
-    "content-kit-utils": "^0.2.0",
     "conventional-changelog": "^0.5.1",
     "jquery": "^2.1.4",
-    "mobiledoc-html-renderer": "^0.2.0",
-    "mobiledoc-text-renderer": "^0.2.0",
     "testem": "^0.9.11"
   },
   "main": "dist/commonjs/mobiledoc-kit/index.js"

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -13,7 +13,7 @@ import Renderer  from 'mobiledoc-kit/renderers/editor-dom';
 import RenderTree from 'mobiledoc-kit/models/render-tree';
 import mobiledocRenderers from '../renderers/mobiledoc';
 
-import { mergeWithOptions } from 'content-kit-utils';
+import { mergeWithOptions } from '../utils/merge';
 import { clearChildNodes, addClassName } from '../utils/dom-utils';
 import { forEach, filter, contains } from '../utils/array-utils';
 import { setData } from '../utils/element-utils';

--- a/src/js/utils/merge.js
+++ b/src/js/utils/merge.js
@@ -1,0 +1,20 @@
+function mergeWithOptions(original, updates, options) {
+  options = options || {};
+  for(var prop in updates) {
+    if (options.hasOwnProperty(prop)) {
+      original[prop] = options[prop];
+    } else if (updates.hasOwnProperty(prop)) {
+      original[prop] = updates[prop];
+    }
+  }
+  return original;
+}
+
+/**
+ * Merges properties of one object into another
+ */
+function merge(original, updates) {
+  return mergeWithOptions(original, updates);
+}
+
+export { mergeWithOptions, merge };

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -3,7 +3,7 @@ import { forEach } from 'mobiledoc-kit/utils/array-utils';
 import KEY_CODES from 'mobiledoc-kit/utils/keycodes';
 import { DIRECTION, MODIFIERS }  from 'mobiledoc-kit/utils/key';
 import { isTextNode } from 'mobiledoc-kit/utils/dom-utils';
-import { merge } from 'content-kit-utils';
+import { merge } from 'mobiledoc-kit/utils/merge';
 
 // walks DOWN the dom from node to childNodes, returning the element
 // for which `conditionFn(element)` is true


### PR DESCRIPTION
Only `merge` and `mergeWithOptions` from content-kit-utils were being used. This PR drops the content-kit-utils dependency altogether in favor of bringing in those functions directly.

It also moves the mobiledoc renderers to be actual dependencies (from dev dependencies) so that commonjs usage will work correctly.

refs #278