### PR TITLE
Expose Mobiledoc.Range

### DIFF
--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -1222,7 +1222,7 @@ class PostEditor {
   /**
    * Add a didUpdate job to the queue
    *
-   * @method scheduleDidRender
+   * @method scheduleDidUpdate
    * @public
    */
   scheduleDidUpdate() {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,9 +1,11 @@
 import Editor from './editor/editor';
 import ImageCard from './cards/image';
+import Range from './utils/cursor/range';
 
 const Mobiledoc = {
   Editor,
-  ImageCard
+  ImageCard,
+  Range
 };
 
 export function registerGlobal(global) {


### PR DESCRIPTION
Expose the Mobiledoc `Range` constructor so that `ember-mobiledoc-editor` can programmatically set the range (in, e.g. the `addCard` action). Refs #286 