### PR TITLE
Always `setRange` in `toggleMarkup` and `toggleSection`

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -306,7 +306,11 @@ class Editor {
 
   // @private
   renderRange() {
-    this.cursor.selectRange(this.range);
+    if (this.range.isBlank) {
+      this.cursor.clearSelection();
+    } else {
+      this.cursor.selectRange(this.range);
+    }
     this._reportSelectionState();
 
     // ensure that the range is "cleaned"/un-cached after

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -849,13 +849,10 @@ class PostEditor {
    * @param {Markup|String} markupOrString Either a markup object created using
    * the builder (useful when adding a markup with attributes, like an 'a' markup),
    * or, if a string, the tag name of the markup (e.g. 'strong', 'em') to toggle.
+   * @param {Range} range in which to toggle, defaults to current editor range
    * @public
    */
-  toggleMarkup(markupOrMarkupString) {
-    const range = this.editor.cursor.offsets;
-    if (range.isCollapsed) {
-      return;
-    }
+  toggleMarkup(markupOrMarkupString, range=this.editor.range) {
     const markup = typeof markupOrMarkupString === 'string' ?
                      this.builder.createMarkup(markupOrMarkupString) :
                      markupOrMarkupString;
@@ -869,7 +866,8 @@ class PostEditor {
     } else {
       this.addMarkupToRange(range, markup);
     }
-    this.scheduleAfterRender(() => this.editor.selectRange(range));
+
+    this.setRange(range);
   }
 
   /**
@@ -887,6 +885,7 @@ class PostEditor {
   toggleSection(sectionTagName, range=this.editor.range) {
     sectionTagName = normalizeTagName(sectionTagName);
     let { post } = this.editor;
+    let nextRange = range;
 
     let everySectionHasTagName = true;
     post.walkMarkerableSections(range, section => {
@@ -903,8 +902,9 @@ class PostEditor {
     });
 
     if (firstChanged) {
-      this.setRange(new Range(firstChanged.headPosition()));
+      nextRange = new Range(firstChanged.headPosition());
     }
+    this.setRange(nextRange);
   }
 
   _isSameSectionType(section, sectionTagName) {

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -54,6 +54,14 @@ export default class Section extends LinkedItem {
     unimplementedMethod('join', this);
   }
 
+  /**
+   * Markerable sections should override this method
+   */
+  splitMarkerAtOffset() {
+    let blankEdit = { added: [], removed: [] };
+    return blankEdit;
+  }
+
   nextLeafSection() {
     const next = this.next;
     if (next) {

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -59,7 +59,7 @@ const Cursor = class Cursor {
    * @return {Range} Cursor#Range object
    */
   get offsets() {
-    if (!this.hasCursor()) { return Range.emptyRange(); }
+    if (!this.hasCursor()) { return Range.blankRange(); }
 
     const { selection, renderTree } = this;
 

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -37,16 +37,17 @@ const Position = class Position {
   constructor(section, offset=0) {
     this.section = section;
     this.offset = offset;
+    this.isBlank = false;
   }
 
-  static emptyPosition() {
+  static blankPosition() {
     return {
       section: null,
       offset: 0,
       marker: null,
       offsetInTextNode: 0,
-      _isEmpty: true,
-      isEqual(other) { return other._isEmpty; },
+      isBlank: true,
+      isEqual(other) { return other.isBlank; },
       markerPosition: {}
     };
   }

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -19,8 +19,8 @@ export default class Range {
     return new Range(section.headPosition(), section.tailPosition());
   }
 
-  static emptyRange() {
-    return new Range(Position.emptyPosition(), Position.emptyPosition());
+  static blankRange() {
+    return new Range(Position.blankPosition(), Position.blankPosition());
   }
 
   /**
@@ -57,6 +57,10 @@ export default class Range {
   isEqual(other) {
     return this.head.isEqual(other.head) &&
            this.tail.isEqual(other.tail);
+  }
+
+  get isBlank() {
+    return this.head.isBlank && this.tail.isBlank;
   }
 
   // "legacy" APIs


### PR DESCRIPTION
This helps prevent a situation where the editor element has a selection
but it is not the active element. Typing while another element (like a
button) is focused (active) but the editor element has the selection is
problematic: The browser refocuses on the editor element and starts
inserting text, but it handles the input before it has focused, which
means the key* handlers do not fire.

  * renamed Position#emptyPosition and Range#emptyRange ->
blankPosition, blankRange. Adds `isBlank` property to Position and
Range.
  * Defensively avoid attempting to render a cursor when the range is blank.
  * Add `splitMarkerAtOffset` to Section base class (fixes #287)

cc @mixonic 

Fixes #285