### PR TITLE
Replace `throw Error` usage with `assert`, use custom `MobiledocError`

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -74,9 +74,8 @@ const CALLBACK_QUEUES = {
  */
 class Editor {
   constructor(options={}) {
-    if (!options || options.nodeType) {
-      throw new Error('editor create accepts an options object. For legacy usage passing an element for the first argument, consider the `html` option for loading DOM or HTML posts. For other cases call `editor.render(domNode)` after editor creation');
-    }
+    assert('editor create accepts an options object. For legacy usage passing an element for the first argument, consider the `html` option for loading DOM or HTML posts. For other cases call `editor.render(domNode)` after editor creation',
+          (options && !options.nodeType));
     this._elementListeners = [];
     this._views = [];
     this.isEditable = null;
@@ -207,9 +206,7 @@ class Editor {
    * @public
    */
   registerExpansion(expansion) {
-    if (!validateExpansion(expansion)) {
-      throw new Error('Expansion is not valid');
-    }
+    assert('Expansion is not valid', validateExpansion(expansion));
     this.expansions.push(expansion);
   }
 
@@ -223,9 +220,7 @@ class Editor {
    */
   registerKeyCommand(rawKeyCommand) {
     const keyCommand = buildKeyCommand(rawKeyCommand);
-    if (!validateKeyCommand(keyCommand)) {
-      throw new Error('Key Command is not valid');
-    }
+    assert('Key Command is not valid', validateKeyCommand(keyCommand));
     this.keyCommands.unshift(keyCommand);
   }
 
@@ -609,7 +604,8 @@ class Editor {
     }
 
     const methodName = `handle${capitalize(eventName)}`;
-    if (!this[methodName]) { throw new Error(`No handler for ${eventName}`); }
+    assert(`No handler "${methodName}" for ${eventName}`, !!this[methodName]);
+
     this[methodName](...args);
   }
 

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -437,15 +437,14 @@ class PostEditor {
     const { section } = position;
     let nextPosition = position.clone();
 
-    if (!section.isMarkerable) {
-      throw new Error('Cannot join non-markerable section to next section');
-    } else {
-      const next = section.immediatelyNextMarkerableSection();
-      if (next) {
-        section.join(next);
-        this._markDirty(section);
-        this.removeSection(next);
-      }
+    assert('Cannot join non-markerable section to next section',
+           section.isMarkerable);
+
+    const next = section.immediatelyNextMarkerableSection();
+    if (next) {
+      section.join(next);
+      this._markDirty(section);
+      this.removeSection(next);
     }
 
     return nextPosition;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,11 +1,13 @@
 import Editor from './editor/editor';
 import ImageCard from './cards/image';
 import Range from './utils/cursor/range';
+import Error from './utils/mobiledoc-error';
 
 const Mobiledoc = {
   Editor,
   ImageCard,
-  Range
+  Range,
+  Error
 };
 
 export function registerGlobal(global) {

--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -57,9 +57,9 @@ export default class Markerable extends Section {
    * @return {Number} The offset relative to the start of this section
    */
   offsetOfMarker(marker, markerOffset) {
-    if (marker.section !== this) {
-      throw new Error(`Cannot get offsetOfMarker for marker that is not child of this`);
-    }
+    assert(`Cannot get offsetOfMarker for marker that is not child of this`,
+           marker.section === this);
+
     // FIXME it is possible, when we get a cursor position before having finished reparsing,
     // for markerOffset to be > marker.length. We shouldn't rely on this functionality.
 
@@ -108,7 +108,7 @@ export default class Markerable extends Section {
   }
 
   splitAtMarker(/*marker, offset=0*/) {
-    throw new Error('splitAtMarker must be implemented by sub-class');
+    assert('splitAtMarker must be implemented by sub-class', false);
   }
 
   /**

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -3,7 +3,8 @@ import LinkedItem from '../utils/linked-item';
 import assert from '../utils/assert';
 
 function unimplementedMethod(methodName, me) {
-  throw new Error(`\`${methodName}()\` must be implemented by ${me.constructor.name}`);
+  assert(`\`${methodName}()\` must be implemented by ${me.constructor.name}`,
+         false);
 }
 
 export default class Section extends LinkedItem {

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -15,10 +15,10 @@ import {
 import {
   DEFAULT_TAG_NAME as DEFAULT_MARKUP_SECTION_TAG_NAME
 } from '../models/markup-section';
-
 import {
   DEFAULT_TAG_NAME as DEFAULT_LIST_SECTION_TAG_NAME
 } from '../models/list-section';
+import assert from '../utils/assert';
 
 function cacheKey(tagName, attributes) {
   return `${normalizeTagName(tagName)}-${objectToSortedKVArray(attributes).join('-')}`;
@@ -54,7 +54,7 @@ export default class PostNodeBuilder {
       case MARKUP_SECTION_TYPE:
         return this.createMarkupSection(tagName, markers);
       default:
-        throw new Error(`Cannot create markerable section of type ${type}`);
+        assert(`Cannot create markerable section of type ${type}`, false);
     }
   }
 

--- a/src/js/models/render-node.js
+++ b/src/js/models/render-node.js
@@ -1,6 +1,7 @@
 import LinkedItem from 'mobiledoc-kit/utils/linked-item';
 import LinkedList from 'mobiledoc-kit/utils/linked-list';
 import { containsNode } from 'mobiledoc-kit/utils/dom-utils';
+import assert from 'mobiledoc-kit/utils/assert';
 
 export default class RenderNode extends LinkedItem {
   constructor(postNode, renderTree) {
@@ -14,9 +15,8 @@ export default class RenderNode extends LinkedItem {
     this.renderTree = renderTree;
   }
   isAttached() {
-    if (!this.element) {
-      throw new Error('Cannot check if a renderNode is attached without an element.');
-    }
+    assert('Cannot check if a renderNode is attached without an element.',
+           !!this.element);
     return containsNode(this.renderTree.rootElement, this.element);
   }
   get childNodes() {

--- a/src/js/parsers/mobiledoc/0-2.js
+++ b/src/js/parsers/mobiledoc/0-2.js
@@ -5,6 +5,7 @@ import {
   MOBILEDOC_CARD_SECTION_TYPE
 } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import { kvArrayToObject, filter } from "../../utils/array-utils";
+import assert from 'mobiledoc-kit/utils/assert';
 
 /*
  * Parses from mobiledoc -> post
@@ -32,7 +33,7 @@ export default class MobiledocParser {
 
       return post;
     } catch (e) {
-      throw new Error(`Unable to parse mobiledoc: ${e.message}`);
+      assert(`Unable to parse mobiledoc: ${e.message}`, false);
     }
   }
 
@@ -65,7 +66,7 @@ export default class MobiledocParser {
         this.parseListSection(section, post);
         break;
       default:
-        throw new Error(`Unexpected section type ${type}`);
+        assert(`Unexpected section type ${type}`, false);
     }
   }
 

--- a/src/js/parsers/mobiledoc/index.js
+++ b/src/js/parsers/mobiledoc/index.js
@@ -1,5 +1,6 @@
 import MobiledocParser_0_2 from './0-2';
 import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
+import assert from 'mobiledoc-kit/utils/assert';
 
 function parseVersion(mobiledoc) {
   return mobiledoc.version;
@@ -12,7 +13,8 @@ export default {
       case MOBILEDOC_VERSION:
         return new MobiledocParser_0_2(builder).parse(mobiledoc);
       default:
-        throw new Error(`Unknown version of mobiledoc parser requested: ${version}`);
+        assert(`Unknown version of mobiledoc parser requested: ${version}`,
+               false);
     }
   }
 };

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -141,7 +141,8 @@ export default class SectionParser {
         this.parseElementNode(node);
         break;
       default:
-        throw new Error(`parseNode got unexpected element type ${node.nodeType} ` + node);
+        assert(`parseNode got unexpected element type ${node.nodeType} ` + node,
+               false);
     }
   }
 
@@ -292,7 +293,7 @@ export default class SectionParser {
         section._inferredTagName = inferredTagName;
         break;
       default:
-        throw new Error('Cannot parse section from element');
+        assert('Cannot parse section from element', false);
     }
 
     return section;

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -305,7 +305,7 @@ class Visitor {
 
 let destroyHooks = {
   [POST_TYPE](/*renderNode, post*/) {
-    throw new Error('post destruction is not supported by the renderer');
+    assert('post destruction is not supported by the renderer', false);
   },
 
   [MARKUP_SECTION_TYPE](renderNode, section) {
@@ -366,9 +366,7 @@ function removeDestroyedChildren(parentNode, forceRemoval=false) {
     if (child.isRemoved || forceRemoval) {
       removeDestroyedChildren(child, true);
       method = child.postNode.type;
-      if (!destroyHooks[method]) {
-        throw new Error(`editor-dom cannot destroy "${method}"`);
-      }
+      assert(`editor-dom cannot destroy "${method}"`, !!destroyHooks[method]);
       destroyHooks[method](child, child.postNode);
       parentNode.childNodes.remove(child);
     }
@@ -427,9 +425,7 @@ export default class Renderer {
       postNode = renderNode.postNode;
 
       method = postNode.type;
-      if (!this.visitor[method]) {
-        throw new Error(`EditorDom visitor cannot handle type ${method}`);
-      }
+      assert(`EditorDom visitor cannot handle type ${method}`, !!this.visitor[method]);
       this.visitor[method](renderNode, postNode,
                            (...args) => this.visit(renderTree, ...args));
       renderNode.markClean();

--- a/src/js/renderers/mobiledoc/index.js
+++ b/src/js/renderers/mobiledoc/index.js
@@ -1,4 +1,5 @@
 import MobiledocRenderer_0_2, { MOBILEDOC_VERSION } from './0-2';
+import assert from 'mobiledoc-kit/utils/assert';
 
 export { MOBILEDOC_VERSION };
 
@@ -10,7 +11,7 @@ export default {
       case null:
         return MobiledocRenderer_0_2.render(post);
       default:
-        throw new Error(`Unknown version of mobiledoc renderer requested: ${version}`);
+        assert(`Unknown version of mobiledoc renderer requested: ${version}`, false);
     }
   }
 };

--- a/src/js/utils/assert.js
+++ b/src/js/utils/assert.js
@@ -1,5 +1,7 @@
+import MobiledocError from './mobiledoc-error';
+
 export default function(message, conditional) {
   if (!conditional) {
-    throw new Error(message);
+    throw new MobiledocError(message);
   }
 }

--- a/src/js/utils/compiler.js
+++ b/src/js/utils/compiler.js
@@ -1,10 +1,9 @@
 import { forEach } from './array-utils';
+import assert from './assert';
 
 export function visit(visitor, node, opcodes) {
   const method = node.type;
-  if (!visitor[method]) {
-    throw new Error(`Cannot visit unknown type ${method}`);
-  }
+  assert(`Cannot visit unknown type ${method}`, !!visitor[method]);
   visitor[method](node, opcodes);
 }
 

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -1,4 +1,5 @@
 import { forEach } from './array-utils';
+import assert from './assert';
 
 export const NODE_TYPES = {
   ELEMENT: 1,
@@ -99,9 +100,8 @@ function findOffsetInElement(elementNode, textNode, offsetInTextNode=0) {
       offset += _textNode.textContent.length;
     }
   });
-  if (!found) {
-    throw new Error('Unable to find offset of text node in element, it is not a child.');
-  }
+  assert('Unable to find offset of text node in element, it is not a child.',
+         found);
   return offset;
 }
 

--- a/src/js/utils/element-map.js
+++ b/src/js/utils/element-map.js
@@ -1,3 +1,5 @@
+import assert from 'mobiledoc-kit/utils/assert';
+
 // start at one to make the falsy semantics easier
 let uuidGenerator = 1;
 
@@ -19,9 +21,7 @@ class ElementMap {
     return null;
   }
   remove(key) {
-    if (!key._uuid) {
-      throw new Error('tried to fetch a value for an element not seen before');
-    }
+    assert('tried to fetch a value for an element not seen before', !!key._uuid);
     delete this._map[key._uuid];
   }
 

--- a/src/js/utils/mobiledoc-error.js
+++ b/src/js/utils/mobiledoc-error.js
@@ -1,0 +1,25 @@
+var errorProps = [
+  'description',
+  'fileName',
+  'lineNumber',
+  'message',
+  'name',
+  'number',
+  'stack'
+];
+
+function MobiledocError() {
+  let tmp = Error.apply(this, arguments);
+
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+  // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
+  for (let idx = 0; idx < errorProps.length; idx++) {
+    this[errorProps[idx]] = tmp[errorProps[idx]];
+  }
+}
+
+MobiledocError.prototype = Object.create(Error.prototype);
+
+export default MobiledocError;

--- a/tests/unit/utils/assert-test.js
+++ b/tests/unit/utils/assert-test.js
@@ -1,0 +1,18 @@
+import Helpers from '../../test-helpers';
+import mobiledocAssert from 'mobiledoc-kit/utils/assert';
+import MobiledocError from 'mobiledoc-kit/utils/mobiledoc-error';
+
+const {module, test} = Helpers;
+
+module('Unit: Utils: assert');
+
+test('#throws a MobiledocError when conditional is false', (assert) => {
+  try {
+    mobiledocAssert('The message', false);
+  } catch (e) {
+    assert.ok(true, 'caught error');
+    assert.equal(e.message, 'The message');
+    assert.ok(e instanceof MobiledocError, 'e instanceof MobiledocError');
+  }
+});
+


### PR DESCRIPTION
This allows upstream consumers to detect and handle MobiledocKit errors
specially if needed.