### PR TITLE
Handle spacebar keydown

### DIFF
--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -28,22 +28,36 @@ function createElementFromMarkup(doc, markup) {
   return element;
 }
 
+const TWO_SPACES         = `${SPACE}${SPACE}`;
+const SPACE_AND_NO_BREAK = `${SPACE}${NO_BREAK_SPACE}`;
+const SPACES_REGEX       = new RegExp(TWO_SPACES, 'g');
+const TAB_REGEX          = new RegExp(TAB, 'g');
+const endsWithSpace = function(text) {
+  return endsWith(text, SPACE);
+};
+const startsWithSpace = function(text) {
+  return startsWith(text, SPACE);
+};
+
 // FIXME: This can be done more efficiently with a single pass
 // building a correct string based on the original.
 function renderHTMLText(marker) {
   let text = marker.value;
+  text = text.replace(SPACES_REGEX, SPACE_AND_NO_BREAK)
+             .replace(TAB_REGEX,    TAB_CHARACTER);
+
   // If the first marker has a leading space or the last marker has a
   // trailing space, the browser will collapse the space when we position
   // the cursor.
   // See https://github.com/bustlelabs/mobiledoc-kit/issues/68
   //   and https://github.com/bustlelabs/mobiledoc-kit/issues/75
-  if (!marker.next && endsWith(text, SPACE)) {
+  if (endsWithSpace(text) && !marker.next) {
     text = text.substr(0, text.length - 1) + NO_BREAK_SPACE;
-  } else if ((!marker.prev || endsWith(marker.prev.value, SPACE)) && startsWith(text, SPACE)) {
+  }
+  if (startsWithSpace(text) &&
+      (!marker.prev || endsWithSpace(marker.prev.value))) {
     text = NO_BREAK_SPACE + text.substr(1);
   }
-  text = text.replace(/ ( )/g, ' '+NO_BREAK_SPACE);
-  text = text.replace(new RegExp(TAB, 'g'), TAB_CHARACTER);
   return text;
 }
 

--- a/src/js/utils/characters.js
+++ b/src/js/utils/characters.js
@@ -1,2 +1,3 @@
 export const TAB = '\t';
 export const ENTER = '\n';
+export const SPACE = ' ';

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -543,6 +543,19 @@ test('deleting when after deletion there is a leading space positions cursor at 
   });
 });
 
+test('inserting multiple spaces renders them with nbsps', (assert) => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection}) => {
+    return post([markupSection()]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  Helpers.dom.insertText(editor, '   ');
+  assert.equal($('#editor p:eq(0)').text(),
+               `${NO_BREAK_SPACE}${NO_BREAK_SPACE}${NO_BREAK_SPACE}`,
+               'correct nbsps in text');
+});
+
 test('deleting when the previous section is also blank', (assert) => {
   editor = new Editor({mobiledoc: mobileDocWithNoCharacter});
   editor.render(editorElement);

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -590,7 +590,7 @@ test('renders markup section "pull-quote" as <div class="pull-quote"></div>', (a
   assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);
 });
 
-test('renders a bunch of spaces with nbsp', (assert) => {
+test('renders characters and spaces with nbsps', (assert) => {
   const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('a b  c    d ')])]);
   });
@@ -599,6 +599,62 @@ test('renders a bunch of spaces with nbsp', (assert) => {
 
   const expectedDOM = Helpers.dom.build(t => {
     return t('p', {}, [t.text(`a b ${NO_BREAK_SPACE}c ${NO_BREAK_SPACE} ${NO_BREAK_SPACE}d${NO_BREAK_SPACE}`)]);
+  });
+
+  assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);
+});
+
+test('renders all spaces with nbsps', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('   ')])]);
+  });
+  const renderTree = new RenderTree(post);
+  render(renderTree);
+
+  const expectedDOM = Helpers.dom.build(t => {
+    return t('p', {}, [t.text(`${NO_BREAK_SPACE}${NO_BREAK_SPACE}${NO_BREAK_SPACE}`)]);
+  });
+
+  assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);
+});
+
+test('renders leading space with nbsp', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker(' a')])]);
+  });
+  const renderTree = new RenderTree(post);
+  render(renderTree);
+
+  const expectedDOM = Helpers.dom.build(t => {
+    return t('p', {}, [t.text(`${NO_BREAK_SPACE}a`)]);
+  });
+
+  assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);
+});
+
+test('renders trailing space with nbsp', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('a ')])]);
+  });
+  const renderTree = new RenderTree(post);
+  render(renderTree);
+
+  const expectedDOM = Helpers.dom.build(t => {
+    return t('p', {}, [t.text(`a${NO_BREAK_SPACE}`)]);
+  });
+
+  assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);
+});
+
+test('renders leading and trailing space with nbsp', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker(' a ')])]);
+  });
+  const renderTree = new RenderTree(post);
+  render(renderTree);
+
+  const expectedDOM = Helpers.dom.build(t => {
+    return t('p', {}, [t.text(`${NO_BREAK_SPACE}a${NO_BREAK_SPACE}`)]);
   });
 
   assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);


### PR DESCRIPTION
Captures keyDown event for `<space>` key and handles it semantically, preventing the event default and inserting a space character into the post. This obviates some mutation-observer code. Browsers fire multiple mutations (removing all spaces in the text node, replacing with spaces + an `&nbsp;`) when typing spaces, and there were issues handling the space appropriately when those mutation observers did not fire at the expected intervals (which could happen if, e.g., there were additional mutation listeners added to the window).

Refactors text expansions to happen on `keyDown` of the trigger key rather than using `setTimeout` and the `DID_REPARSE` callback queue. This fixes another issue where typing characters too quickly would not cause the text expansion to fire (typing "* X" very quickly, e.g., could make it so that the text expansion code ran after the "X" was inserted and would not properly expand into a list item).

cc @mixonic 

fixes #292