### PR TITLE
Satisfy newer jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,7 +31,6 @@
   "undef"         : true,     // Require all non-global variables be declared before they are used.
   "unused"        : true,     // Warn when variables are created but not used.
   "trailing"      : true,     // Prohibit trailing whitespaces.
-  "es3"           : true,     // Prohibit trailing commas for old IE 
   "esnext"        : true,     // Allow ES.next specific features such as `const` and `let`.
   
   // == Relaxing Options ================================================

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -665,6 +665,7 @@ class Editor {
         this.handleNewline(event);
         break;
       case key.isPrintable():
+      {
         let { offsets: range } = this.cursor;
         let { isCollapsed } = range;
         let nextPosition = range.head;
@@ -695,6 +696,7 @@ class Editor {
           event.preventDefault();
         }
         break;
+      }
     }
   }
 

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -440,8 +440,10 @@ export default class Renderer {
 
       method = postNode.type;
       assert(`EditorDom visitor cannot handle type ${method}`, !!this.visitor[method]);
+      // jshint -W083
       this.visitor[method](renderNode, postNode,
                            (...args) => this.visit(renderTree, ...args));
+      // jshint +W083
       renderNode.markClean();
       renderNode = this.nodes.shift();
     }

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -19,7 +19,9 @@ function walkDOMUntil(topNode, conditionFn=() => {}) {
       return currentElement;
     }
 
-    forEach(currentElement.childNodes, (el) => stack.push(el));
+    // jshint -W083
+    forEach(currentElement.childNodes, el => stack.push(el));
+    // jshint +W083
   }
 }
 


### PR DESCRIPTION
Newish versions of jshint (I'm using 2.9.1) have bugfixes that cause it to discover failures that were missed by earlier versions.

 - I had to remove the `es3` option because it doesn't not work correctly alongside `esnext`
 - I created a new scope in editor.js because a switch case was shadowing outer variables
 - W083 is the "don't make functions within a loop" error, which is sensible in general, but not needed when you're sure that the functions in question will not outlive a single loop iteration.