### PR TITLE
Report active markups even when selection is collapsed

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -381,7 +381,7 @@ class Editor {
   }
 
   get markupsInSelection() {
-    if (this.cursor.hasSelection()) {
+    if (this.cursor.hasCursor()) {
       const range = this.cursor.offsets;
       return this.post.markupsInRange(range);
     } else {

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -517,3 +517,26 @@ test('editor#selectSections works when given an empty array', (assert) => {
   editor.selectSections([]);
   assert.selectedText(null, 'no text selected after selecting no sections');
 });
+
+test('placing cursor inside a strong section should cause markupsInSelection to contain "strong"', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker, markup}) => {
+    const b = markup('strong');
+    return post([markupSection('p', [
+      marker('before'),
+      marker('loud',[b]),
+      marker('after')
+    ])]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+
+  Helpers.dom.moveCursorTo($('#editor strong')[0].firstChild, 1);
+
+  let bold = editor.builder.createMarkup('strong');
+  assert.ok(editor.markupsInSelection.indexOf(bold) !== -1, 'strong is in selection');
+
+  Helpers.dom.moveCursorTo($('#editor')[0].childNodes[0], 1);
+
+  assert.ok(editor.markupsInSelection.indexOf(bold) === -1, 'strong is not in selection');
+});


### PR DESCRIPTION
This makes `markupsInSelection` report active markups even when the selection is collapsed.

If you run the demo, you can see why this is helpful:

 - mark some words bold
 - move the cursor in and out of the bold region
 - observe that the toolbar button for "Bold" correctly shows active state when you're inside the bold region. Prior to this change, the toolbar button would only show active state if you highlighted one or more characters inside a bold region.