### PR TITLE
Add MutationHandler, reparse entire post when new nodes appear

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -39,6 +39,7 @@ import {
 import { DIRECTION } from 'mobiledoc-kit/utils/key';
 import { TAB, SPACE } from 'mobiledoc-kit/utils/characters';
 import assert from '../utils/assert';
+import MutationHandler from 'mobiledoc-kit/editor/mutation-handler';
 
 export const EDITOR_ELEMENT_CLASS_NAME = '__mobiledoc-editor';
 
@@ -89,10 +90,6 @@ class Editor {
     DEFAULT_TEXT_EXPANSIONS.forEach(e => this.registerExpansion(e));
     DEFAULT_KEY_COMMANDS.forEach(kc => this.registerKeyCommand(kc));
 
-    this._mutationObserver = new MutationObserver(() => {
-      this.handleInput();
-    });
-    this._isMutationObserved = false;
     this._parser   = new DOMParser(this.builder);
     this._renderer = new Renderer(this, this.cards, this.unknownCardHandler, this.cardOptions);
 
@@ -137,9 +134,9 @@ class Editor {
     }
 
     this.runCallbacks(CALLBACK_QUEUES.WILL_RENDER);
-    this.removeMutationObserver();
-    this._renderer.render(this._renderTree);
-    this.ensureMutationObserver();
+    this._mutationHandler.suspendObservation(() => {
+      this._renderer.render(this._renderTree);
+    });
     this.runCallbacks(CALLBACK_QUEUES.DID_RENDER);
   }
 
@@ -154,6 +151,8 @@ class Editor {
     clearChildNodes(element);
 
     this.element = element;
+    this._mutationHandler = new MutationHandler(this);
+    this._mutationHandler.startObserving();
 
     if (this.isEditable === null) {
       this.enableEditing();
@@ -317,33 +316,33 @@ class Editor {
     setData(this.element, 'placeholder', placeholder);
   }
 
-  /**
-   * types of input to handle:
-   *   * delete from beginning of section
-   *       joins 2 sections
-   *   * delete when multiple sections selected
-   *       removes wholly-selected sections,
-   *       joins the partially-selected sections
-   *   * hit enter (handled by capturing 'keydown' for enter key and `handleNewline`)
-   *       if anything is selected, delete it first, then
-   *       split the current marker at the cursor position,
-   *         schedule removal of every marker after the split,
-   *         create new section, append it to post
-   *         append the after-split markers onto the new section
-   *         rerender -- this should render the new section at the appropriate spot
-   */
-  handleInput() {
-    this.reparse();
+  _reparsePost() {
+    this.post = this._parser.parse(this.element);
+    this._renderTree = new RenderTree(this.post);
+    clearChildNodes(this.element);
+    this.rerender();
+
+    this.runCallbacks(CALLBACK_QUEUES.DID_REPARSE);
+    this.didUpdate();
   }
 
-  reparse() {
-    this._reparseCurrentSection();
+  _reparseSections(sections=[]) {
+    let currentRange;
+    sections.forEach(section => {
+      this._parser.reparseSection(section, this._renderTree);
+    });
     this._removeDetachedSections();
 
-    // A call to `run` will trigger the didUpdatePostCallbacks hooks with a
-    // postEditor.
+    if (this._renderTree.isDirty) {
+      currentRange = this.range;
+    }
+
     this.run(() => {});
     this.rerender();
+    if (currentRange) {
+      this.selectRange(currentRange);
+    }
+
     this.runCallbacks(CALLBACK_QUEUES.DID_REPARSE);
     this.didUpdate();
   }
@@ -389,13 +388,6 @@ class Editor {
     }
   }
 
-  _reparseCurrentSection() {
-    const {headSection:currentSection } = this.cursor.offsets;
-    if (currentSection) {
-      this._parser.reparseSection(currentSection, this._renderTree);
-    }
-  }
-
   serialize() {
     return mobiledocRenderers.render(this.post);
   }
@@ -405,32 +397,15 @@ class Editor {
     this._views = [];
   }
 
-  ensureMutationObserver() {
-    if (!this._isMutationObserved) {
-      this._mutationObserver.observe(this.element, {
-        characterData: true,
-        childList: true,
-        subtree: true
-      });
-      this._isMutationObserved = true;
-    }
-  }
-
-  removeMutationObserver() {
-    if (this._isMutationObserved) {
-      this._mutationObserver.disconnect();
-      this._isMutationObserved = false;
-    }
-  }
-
   destroy() {
     this._isDestroyed = true;
     if (this.cursor.hasCursor()) {
       this.cursor.clearSelection();
       this.element.blur();
     }
-    this.removeMutationObserver();
-    this._mutationObserver = null;
+    if (this._mutationHandler) {
+      this._mutationHandler.destroy();
+    }
     this.removeAllEventListeners();
     this.removeAllViews();
     this._renderer.destroy();
@@ -565,6 +540,16 @@ class Editor {
     this.addCallback(CALLBACK_QUEUES.CURSOR_DID_CHANGE, callback);
   }
 
+  /**
+   * @method didReparse
+   * @param {Function} callback This callback is called after any part of the
+   *        post is reparsed
+   * @public
+   */
+  didReparse(callback) {
+    this.addCallback(CALLBACK_QUEUES.DID_REPARSE, callback);
+  }
+
   _setupListeners() {
     ELEMENT_EVENTS.forEach(eventName => {
       this.addEventListener(this.element, eventName,
@@ -665,8 +650,7 @@ class Editor {
         this.handleNewline(event);
         break;
       case key.isPrintable():
-      {
-        let { offsets: range } = this.cursor;
+        let { range } = this;
         let { isCollapsed } = range;
         let nextPosition = range.head;
 
@@ -696,7 +680,6 @@ class Editor {
           event.preventDefault();
         }
         break;
-      }
     }
   }
 

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -540,16 +540,6 @@ class Editor {
     this.addCallback(CALLBACK_QUEUES.CURSOR_DID_CHANGE, callback);
   }
 
-  /**
-   * @method didReparse
-   * @param {Function} callback This callback is called after any part of the
-   *        post is reparsed
-   * @public
-   */
-  didReparse(callback) {
-    this.addCallback(CALLBACK_QUEUES.DID_REPARSE, callback);
-  }
-
   _setupListeners() {
     ELEMENT_EVENTS.forEach(eventName => {
       this.addEventListener(this.element, eventName,

--- a/src/js/editor/mutation-handler.js
+++ b/src/js/editor/mutation-handler.js
@@ -1,0 +1,129 @@
+import Set from 'mobiledoc-kit/utils/set';
+import { forEach, filter } from 'mobiledoc-kit/utils/array-utils';
+import assert from 'mobiledoc-kit/utils/assert';
+
+const MUTATION = {
+  NODES_CHANGED: 'childList',
+  CHARACTER_DATA: 'characterData'
+};
+
+export default class MutationHandler {
+  constructor(editor) {
+    this.editor     = editor;
+    this.renderTree = null;
+    this._isObserving = false;
+
+    this._observer = new MutationObserver((mutations) => {
+      this._handleMutations(mutations);
+    });
+  }
+
+  destroy() {
+    this.stopObserving();
+    this._observer = null;
+  }
+
+  suspendObservation(callback) {
+    this.stopObserving();
+    callback();
+    this.startObserving();
+  }
+
+  stopObserving() {
+    if (this._isObserving) {
+      this._isObserving = false;
+      this._observer.disconnect();
+    }
+  }
+
+  startObserving() {
+    if (!this._isObserving) {
+      let { editor } = this;
+      assert('Cannot observe un-rendered editor', editor.hasRendered);
+
+      this._isObserving = true;
+      this.renderTree = editor._renderTree;
+
+      this._observer.observe(editor.element, {
+        characterData: true,
+        childList: true,
+        subtree: true
+      });
+    }
+  }
+
+  reparsePost() {
+    this.editor._reparsePost();
+  }
+
+  reparseSections(sections) {
+    this.editor._reparseSections(sections);
+  }
+
+  /**
+   * for each mutation:
+   *   * find the target nodes:
+   *     * if nodes changed, target nodes are:
+   *        * added nodes
+   *        * the target from which removed nodes were removed
+   *     * if character data changed
+   *       * target node is the mutation event's target (text node)
+   *     * filter out nodes that are no longer attached (parentNode is null)
+   *   * for each remaining node:
+   *   *  find its section, add to sections-to-reparse
+   *   *  if no section, reparse all (and break)
+   */
+  _handleMutations(mutations) {
+    let reparsePost = false;
+    let sections = new Set();
+
+    for (let i = 0; i < mutations.length; i++) {
+      if (reparsePost) {
+        break;
+      }
+
+      let nodes = this._findTargetNodes(mutations[i]);
+
+      for (let j=0; j < nodes.length; j++) {
+        let section = this._findSectionFromNode(nodes[j]);
+        if (section) {
+          sections.add(section);
+        } else {
+          reparsePost = true;
+          break;
+        }
+      }
+    }
+
+    if (reparsePost) {
+      this.reparsePost();
+    } else if (sections.length) {
+      this.reparseSections(sections.toArray());
+    }
+  }
+
+  _findTargetNodes(mutation) {
+    let nodes = [];
+    switch (mutation.type) {
+      case MUTATION.CHARACTER_DATA:
+        nodes.push(mutation.target);
+        break;
+      case MUTATION.NODES_CHANGED:
+        forEach(mutation.addedNodes, n => nodes.push(n));
+        if (mutation.removedNodes.length) {
+          nodes.push(mutation.target);
+        }
+        break;
+    }
+
+    let attachedNodes = filter(nodes, node => !!node.parentNode);
+    return attachedNodes;
+  }
+
+  _findSectionFromNode(node) {
+    let rn = this.renderTree.findRenderNodeFromElement(node, (rn) => {
+      return rn.postNode.isSection;
+    });
+    return rn && rn.postNode;
+  }
+}

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -12,6 +12,7 @@ export default class Section extends LinkedItem {
     super();
     assert('Cannot create section without type', !!type);
     this.type = type;
+    this.isSection = true;
     this.isMarkerable = false;
     this.isNested = false;
     this.isSection = true;

--- a/src/js/models/render-tree.js
+++ b/src/js/models/render-tree.js
@@ -12,6 +12,12 @@ export default class RenderTree {
   get rootNode() {
     return this._rootNode;
   }
+  /**
+   * @return {Boolean}
+   */
+  get isDirty() {
+    return this.rootNode && this.rootNode.isDirty;
+  }
   /*
    * @return {DOMNode} The root DOM element in this tree
    */

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -194,6 +194,7 @@ export default class DOMParser {
         renderNode = renderTree.buildRenderNode(marker);
         renderNode.element = textNode;
         renderNode.markClean();
+        section.renderNode.markDirty();
 
         let previousRenderNode = previousMarker && previousMarker.renderNode;
         section.markers.insertAfter(marker, previousMarker);

--- a/src/js/utils/set.js
+++ b/src/js/utils/set.js
@@ -10,6 +10,10 @@ export default class Set {
     }
   }
 
+  get length() {
+    return this.items.length;
+  }
+
   has(item) {
     return this.items.indexOf(item) !== -1;
   }

--- a/tests/acceptance/editor-reparse-test.js
+++ b/tests/acceptance/editor-reparse-test.js
@@ -3,7 +3,7 @@ const { test, module } = Helpers;
 
 let editor, editorElement;
 
-module('Acceptance: editor: reparsing', {
+module('Acceptance: Editor: Reparsing', {
   beforeEach() {
     editorElement = $('#editor')[0];
   },
@@ -21,9 +21,6 @@ test('changing text node content causes reparse of section', (assert) => {
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let reparsed = false;
-  editor.didReparse(() => reparsed = true);
-
   let section = editor.post.sections.head;
   let node = section.markers.head.renderNode.element;
 
@@ -35,7 +32,6 @@ test('changing text node content causes reparse of section', (assert) => {
   setTimeout(() => {
     assert.equal(section.text, 'def', 'section reparsed correctly');
     assert.postIsSimilar(editor.post, expected);
-    assert.ok(reparsed, 'did reparse');
     done();
   });
 });
@@ -49,9 +45,6 @@ test('removing text node causes reparse of section', (assert) => {
     return post([markupSection('p', [marker('abc'), marker('def')])]);
   });
 
-  let reparsed = false;
-  editor.didReparse(() => reparsed = true);
-
   let section = editor.post.sections.head;
   let node = section.markers.head.renderNode.element;
 
@@ -63,7 +56,6 @@ test('removing text node causes reparse of section', (assert) => {
   setTimeout(() => {
     assert.equal(section.text, 'def', 'section reparsed correctly');
     assert.postIsSimilar(editor.post, expected);
-    assert.ok(reparsed, 'did reparse');
     done();
   });
 });
@@ -80,9 +72,6 @@ test('removing section node causes reparse of post', (assert) => {
     ]);
   });
 
-  let reparsed = false;
-  editor.didReparse(() => reparsed = true);
-
   let node = editor.post.sections.head.renderNode.element;
   assert.equal(node.innerHTML, 'abc', 'precond - correct node');
 
@@ -90,7 +79,6 @@ test('removing section node causes reparse of post', (assert) => {
 
   setTimeout(() => {
     assert.postIsSimilar(editor.post, expected);
-    assert.ok(reparsed, 'did reparse');
     done();
   });
 });
@@ -106,9 +94,6 @@ test('inserting styled span in section causes section reparse', (assert) => {
     ]);
   });
 
-  let reparsed = false;
-  editor.didReparse(() => reparsed = true);
-
   let node = editor.post.sections.head.renderNode.element;
   assert.equal(node.innerHTML, 'abc', 'precond - correct node');
 
@@ -119,7 +104,6 @@ test('inserting styled span in section causes section reparse', (assert) => {
 
   setTimeout(() => {
     assert.postIsSimilar(editor.post, expected);
-    assert.ok(reparsed, 'did reparse');
     done();
   });
 });
@@ -136,16 +120,12 @@ test('inserting new top-level node causes reparse of post', (assert) => {
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let reparsed = false;
-  editor.didReparse(() => reparsed = true);
-
   let span = document.createElement('span');
   span.appendChild(document.createTextNode('123'));
   editorElement.appendChild(span);
 
   setTimeout(() => {
     assert.postIsSimilar(editor.post, expected);
-    assert.ok(reparsed, 'did reparse');
     done();
   });
 });
@@ -159,16 +139,12 @@ test('inserting node into blank post causes reparse', (assert) => {
     return post();
   });
 
-  let reparsed = false;
-  editor.didReparse(() => reparsed = true);
-
   let span = document.createElement('span');
   span.appendChild(document.createTextNode('123'));
   editorElement.appendChild(span);
 
   setTimeout(() => {
     assert.postIsSimilar(editor.post, expected);
-    assert.ok(reparsed, 'did reparse');
     done();
   });
 });
@@ -190,17 +166,12 @@ test('after reparsing post, mutations still handled properly', (assert) => {
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let reparsed = false;
-  editor.didReparse(() => reparsed = true);
-
   let span = document.createElement('span');
   span.appendChild(document.createTextNode('123'));
   editorElement.appendChild(span);
 
   setTimeout(() => {
     assert.postIsSimilar(editor.post, expected1);
-    assert.ok(reparsed, 'did reparse');
-    reparsed = false;
 
     let node = editorElement.firstChild.firstChild;
     assert.equal(node.textContent, 'abc', 'precond - correct node');
@@ -208,7 +179,6 @@ test('after reparsing post, mutations still handled properly', (assert) => {
     node.textContent = 'def';
 
     setTimeout(() => {
-      assert.ok(reparsed, 'reparsed again');
       assert.postIsSimilar(editor.post, expected2);
 
       done();

--- a/tests/acceptance/editor-reparse-test.js
+++ b/tests/acceptance/editor-reparse-test.js
@@ -1,0 +1,217 @@
+import Helpers from '../test-helpers';
+const { test, module } = Helpers;
+
+let editor, editorElement;
+
+module('Acceptance: editor: reparsing', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('changing text node content causes reparse of section', (assert) => {
+  let done = assert.async();
+  let expected;
+  let editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([markupSection('p', [marker('def')])]);
+
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let reparsed = false;
+  editor.didReparse(() => reparsed = true);
+
+  let section = editor.post.sections.head;
+  let node = section.markers.head.renderNode.element;
+
+  assert.equal(node.textContent, 'abc', 'precond - correct text node');
+  assert.equal(section.text, 'abc', 'precond - correct section');
+
+  node.textContent = 'def';
+
+  setTimeout(() => {
+    assert.equal(section.text, 'def', 'section reparsed correctly');
+    assert.postIsSimilar(editor.post, expected);
+    assert.ok(reparsed, 'did reparse');
+    done();
+  });
+});
+
+test('removing text node causes reparse of section', (assert) => {
+  let done = assert.async();
+  let expected;
+  let editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([markupSection('p', [marker('def')])]);
+
+    return post([markupSection('p', [marker('abc'), marker('def')])]);
+  });
+
+  let reparsed = false;
+  editor.didReparse(() => reparsed = true);
+
+  let section = editor.post.sections.head;
+  let node = section.markers.head.renderNode.element;
+
+  assert.equal(node.textContent, 'abc', 'precond - correct text node');
+  assert.equal(section.text, 'abcdef', 'precond - correct section');
+
+  node.parentNode.removeChild(node);
+
+  setTimeout(() => {
+    assert.equal(section.text, 'def', 'section reparsed correctly');
+    assert.postIsSimilar(editor.post, expected);
+    assert.ok(reparsed, 'did reparse');
+    done();
+  });
+});
+
+test('removing section node causes reparse of post', (assert) => {
+  let done = assert.async();
+  let expected;
+  let editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([markupSection('p', [marker('123')])]);
+
+    return post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('123')])
+    ]);
+  });
+
+  let reparsed = false;
+  editor.didReparse(() => reparsed = true);
+
+  let node = editor.post.sections.head.renderNode.element;
+  assert.equal(node.innerHTML, 'abc', 'precond - correct node');
+
+  node.parentNode.removeChild(node);
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.ok(reparsed, 'did reparse');
+    done();
+  });
+});
+
+test('inserting styled span in section causes section reparse', (assert) => {
+  let done = assert.async();
+  let expected;
+  let editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([markupSection('p', [marker('abc'), marker('def')])]);
+
+    return post([
+      markupSection('p', [marker('abc')])
+    ]);
+  });
+
+  let reparsed = false;
+  editor.didReparse(() => reparsed = true);
+
+  let node = editor.post.sections.head.renderNode.element;
+  assert.equal(node.innerHTML, 'abc', 'precond - correct node');
+
+  let span = document.createElement('span');
+  span.setAttribute('style','font-size: 24px; font-color: blue');
+  span.appendChild(document.createTextNode('def'));
+  node.appendChild(span);
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.ok(reparsed, 'did reparse');
+    done();
+  });
+});
+
+test('inserting new top-level node causes reparse of post', (assert) => {
+  let done = assert.async();
+  let expected;
+  let editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('123')])
+    ]);
+
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let reparsed = false;
+  editor.didReparse(() => reparsed = true);
+
+  let span = document.createElement('span');
+  span.appendChild(document.createTextNode('123'));
+  editorElement.appendChild(span);
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.ok(reparsed, 'did reparse');
+    done();
+  });
+});
+
+test('inserting node into blank post causes reparse', (assert) => {
+  let done = assert.async();
+  let expected;
+
+  let editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([markupSection('p', [marker('123')])]);
+    return post();
+  });
+
+  let reparsed = false;
+  editor.didReparse(() => reparsed = true);
+
+  let span = document.createElement('span');
+  span.appendChild(document.createTextNode('123'));
+  editorElement.appendChild(span);
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.ok(reparsed, 'did reparse');
+    done();
+  });
+});
+
+test('after reparsing post, mutations still handled properly', (assert) => {
+  let done = assert.async();
+  let expected1, expected2;
+  let editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected1 = post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('123')])
+    ]);
+
+    expected2 = post([
+      markupSection('p', [marker('def')]),
+      markupSection('p', [marker('123')])
+    ]);
+
+    return post([markupSection('p', [marker('abc')])]);
+  });
+
+  let reparsed = false;
+  editor.didReparse(() => reparsed = true);
+
+  let span = document.createElement('span');
+  span.appendChild(document.createTextNode('123'));
+  editorElement.appendChild(span);
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected1);
+    assert.ok(reparsed, 'did reparse');
+    reparsed = false;
+
+    let node = editorElement.firstChild.firstChild;
+    assert.equal(node.textContent, 'abc', 'precond - correct node');
+
+    node.textContent = 'def';
+
+    setTimeout(() => {
+      assert.ok(reparsed, 'reparsed again');
+      assert.postIsSimilar(editor.post, expected2);
+
+      done();
+    });
+  });
+});

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -1,8 +1,6 @@
 import DOMParser from 'mobiledoc-kit/parsers/dom';
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 import Helpers from '../../test-helpers';
-import { Editor } from 'mobiledoc-kit';
-import { NO_BREAK_SPACE } from 'mobiledoc-kit/renderers/editor-dom';
 import { TAB } from 'mobiledoc-kit/utils/characters';
 
 const {module, test} = Helpers;
@@ -68,77 +66,6 @@ test('#parse can parse tabs', (assert) => {
   let s1 = post.sections.head;
   assert.equal(s1.markers.length, 1, 's1 has 1 marker');
   assert.equal(s1.markers.head.value, `a${TAB}b`);
-});
-
-test('editor#reparse catches changes to section', (assert) => {
-  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) =>
-    post([
-      markupSection('p', [marker('the marker')])
-    ])
-  );
-  editor = new Editor({mobiledoc});
-  editor.render(editorElement);
-
-  assert.hasElement('#editor p:contains(the marker)', 'precond - rendered correctly');
-
-  const p = $('#editor p:eq(0)')[0];
-  p.childNodes[0].textContent = 'the NEW marker';
-
-  // In Firefox, changing the text content changes the selection, so re-set it
-  Helpers.dom.moveCursorTo(p.childNodes[0]);
-
-  editor.reparse();
-
-  const section = editor.post.sections.head;
-  assert.equal(section.text, 'the NEW marker');
-});
-
-test('editor#reparse parses spaces and breaking spaces', (assert) => {
-  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) =>
-    post([
-      markupSection('p', [marker('the marker')])
-    ])
-  );
-  editor = new Editor({mobiledoc});
-  editor.render(editorElement);
-
-  assert.hasElement('#editor p:contains(the marker)', 'precond - rendered correctly');
-
-  const p = $('#editor p:eq(0)')[0];
-  p.childNodes[0].textContent = `some ${NO_BREAK_SPACE}text ${NO_BREAK_SPACE}${NO_BREAK_SPACE}for ${NO_BREAK_SPACE} ${NO_BREAK_SPACE}you`;
-
-  // In Firefox, changing the text content changes the selection, so re-set it
-  Helpers.dom.moveCursorTo(p.childNodes[0]);
-
-  editor.reparse();
-
-  const section = editor.post.sections.head;
-  assert.equal(section.text, 'some  text   for    you');
-});
-
-test('editor#reparse catches changes to list section', (assert) => {
-  const mobiledoc = Helpers.mobiledoc.build(({post, listSection, listItem, marker}) =>
-    post([
-      listSection('ul', [
-        listItem([marker('the list item')])
-      ])
-    ])
-  );
-  editor = new Editor({mobiledoc});
-  editor.render(editorElement);
-
-  assert.hasElement('#editor li:contains(list item)', 'precond - rendered correctly');
-
-  const li = $('#editor li:eq(0)')[0];
-  li.childNodes[0].textContent = 'the NEW list item';
-
-  // In Firefox, changing the text content changes the selection, so re-set it
-  Helpers.dom.moveCursorTo(li.childNodes[0]);
-
-  editor.reparse();
-
-  const listItem = editor.post.sections.head.items.head;
-  assert.equal(listItem.text, 'the NEW list item');
 });
 
 test('parse empty content', (assert) => {


### PR DESCRIPTION
## summary of changes

  * adds editor#_reparseSections and editor#_reparsePost
  * adds RenderTree#isDirty, use it to determine whether to rerender
    the cursor position after reparsing
  * tests for changing text and element nodes in the editor dom
  * Remove editor#reparse and #_reparseCurrentSection

## previous reparsing algorithm
Previously, the reparsing algorithm was, roughly:
  * after detecting a mutation(s) (any mutation: added/removed node or any character data change),
  * call editor#_reparseCurrentSection, which:
  * reparse only the section that currently has the cursor in it

This misses changes to the DOM that happened outside the section with the cursor (which happens when dragging in text to the editor if it has no cursor (ie is blank), and/or when dragging in text that causes the browser to insert dom outside the section that has the cursor (ie when dragging multiple lines of text)).

## new reparsing algorithm

Now, the reparsing algorithm inspects the mutation events to determine which section(s) are affected or if the entire post is affected and must be reparsed. The new algorithm is, roughly:
  * for each mutation event, find the significant nodes (added nodes are significant, the target element from which nodes are removed is significant, and the text nodes that have changed character data are significant)
  * prune those significant nodes by removing any that are not attached to any parent node (this can happen when the browser makes multiple mutations at once; when the mutation observer callback fires some of the mutations now point at dom nodes that have since been removed)
  * for each remaining significant node, look up its section from the render tree. If no section is found, we must reparse the entire post (because a node must have been added in the editor outside of one of our rendered sections)
  * either reparse the entire post (if necessary), or reparse the section(s) that we found in the previous step
  * if reparsing sections, and any section gets marked dirty, we must rerender the cursor

Changes to DOMParser#reparseSection:
  * the reparseSection method was primarily intended to detect text changes due to character input to the text node(s) in a section. As such, it assumes the DOM in that section is "clean" and it only walks the text nodes and fixes up their corresponding markers so that the post model represents what is in DOM and its render nodes are marked clean. (A better method name might be `readSectionFromDOM`).
  * but it is possible to change the DOM nodes in a section in other ways, particularly by dragging in text. In this case the browser may insert new elements (spans with inline styles, in particular) for the dragged-in text, and it's no longer safe to assume that the section's DOM is "clean". We want to read the DOM for that section but then also rerender it (to remove the extraneous DOM nodes that the browser may have added)
  * to facilitate this, the DOMParser#reparseSection method is changed so that it will update-in-place a marker when it encounters a known text node, but any *new* text nodes (i.e. ones that have correspond to no render node) will cause it to mark the section's render node as dirty. The editor, after reparsing the section, checks to see if the render tree is dirty and if so it rerenders (and also rerenders the cursor position)

fixes #300 