### PR TITLE
Skip all non-text, non-element nodes in SectionParser

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -140,9 +140,6 @@ export default class SectionParser {
       case NODE_TYPES.ELEMENT:
         this.parseElementNode(node);
         break;
-      default:
-        assert(`parseNode got unexpected element type ${node.nodeType} ` + node,
-               false);
     }
   }
 

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -162,7 +162,7 @@ test('#parse skips STYLE nodes', (assert) => {
   assert.equal(sections.length, 0, 'does not parse style');
 });
 
-test('#parse skips Comment nodes', (assert) => {
+test('#parse skips top-level Comment nodes', (assert) => {
   let element = buildDOM(`
     <!--Some comment-->
   `).firstChild;
@@ -170,4 +170,17 @@ test('#parse skips Comment nodes', (assert) => {
   let sections = parser.parse(element);
 
   assert.equal(sections.length, 0, 'does not parse comments');
+});
+
+test('#parse skips nested Comment nodes', (assert) => {
+  let element = buildDOM(`
+   <p><!--Some comment-->some text<!-- another comment --></p>
+  `).firstChild;
+  parser = new SectionParser(builder);
+  let sections = parser.parse(element);
+
+  assert.equal(sections.length, 1);
+  let section = sections[0];
+  assert.equal(section.text, 'some text', 'parses text surrounded by comments');
+  assert.equal(section.markers.length, 1, 'only 1 marker');
 });


### PR DESCRIPTION
Remove the assertion when encountering an unexpected node type. These nodes can simply be skipped.
Adds a test for parsing dom that has a nested comment node.