### PR TITLE
Use marker's rendered `markupElement` for destroying marker render nodes

### DIFF
--- a/src/js/models/render-node.js
+++ b/src/js/models/render-node.js
@@ -13,6 +13,9 @@ export default class RenderNode extends LinkedItem {
     this._childNodes = null;
     this._element = null;
     this.renderTree = renderTree;
+
+    // RenderNodes for Markers keep track of their markupElement
+    this.markupElement = null;
   }
   isAttached() {
     assert('Cannot check if a renderNode is attached without an element.',

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -236,3 +236,34 @@ test('typing enter splits lines, sets cursor', (assert) => {
     done();
   }, 0);
 });
+
+// see https://github.com/bustlelabs/mobiledoc-kit/issues/306
+test('adding/removing bold text between two bold markers works', (assert) => {
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker, markup}) => {
+    return post([
+      markupSection('p', [
+        marker('abc', [markup('b')]),
+        marker('123', []),
+        marker('def', [markup('b')])
+      ])
+    ]);
+  });
+
+  // preconditions
+  assert.hasElement('#editor b:contains(abc)');
+  assert.hasElement('#editor b:contains(def)');
+  assert.hasNoElement('#editor b:contains(123)');
+
+  Helpers.dom.selectText('123', editorElement);
+  editor.run(postEditor => postEditor.toggleMarkup('b'));
+
+  assert.hasElement('#editor b:contains(abc123def)', 'adds B to selection');
+
+  assert.equal(Helpers.dom.getSelectedText(), '123', '123 still selected');
+
+  editor.run(postEditor => postEditor.toggleMarkup('b'));
+
+  assert.hasElement('#editor b:contains(abc)', 'removes B from middle, leaves abc');
+  assert.hasElement('#editor b:contains(def)', 'removes B from middle, leaves def');
+  assert.hasNoElement('#editor b:contains(123)', 'removes B from middle');
+});


### PR DESCRIPTION
Changes the editor-dom renderer to store a reference to the last markup element it created (as `renderNode.markupElement`) when rendering a marker. Use this markup element in the destroy hook for markers rather counting the marker's markups and walking the DOM.

Previously, when destroying a marker, the renderer would count the marker's markups and walk up that many `parentNode`s from the renderNode's `element` (the textNode for the marker). But it is possible for a marker's number of markups to change after it has been rendered but before it is removed. In these cases, walking up `marker.markups.length` of `parentNode`s from the marker's textNode `element` could result in incorrectly removing more DOM (i.e. a parent P element) than it should.

Fixes #306
Fixes #299