### PR TITLE
Initial atoms implementation

### DIFF
--- a/ATOMS.md
+++ b/ATOMS.md
@@ -1,0 +1,58 @@
+# Mobiledoc Atoms
+
+Atoms are effectively read-only inline cards.
+
+## Atom format
+
+An atom is a JavaScript object with 3 *required* properties:
+
+  * `name` [string] - The name of this atom in the mobiledoc
+  * `type` [string] - The output of this atom. Valid values are 'dom', 'html', and 'text'
+  * `render` [function] - Invoked by the renderer to render this atom
+
+## Atom rendering
+
+The `render` function on an atom is called by an instance of a renderer and passed an object with the following four properties:
+
+  * `env` [object] - A set of environment-specific properties
+  * `options` [object] - Rendering options that were passed to the renderer (as `cardOptions`) when it was instantiated
+  * `payload` [object] - The data payload for this atom from the mobiledoc
+  * `value` [string] - The textual representation to for this atom
+
+The return value of the `render` function will be inserted by the renderer into the rendered mobiledoc.
+The return value can be null if an atom does not have any output. If there is a return value it
+must be of the correct type (a DOM Node for the dom renderer, a string of html or text for the html or text renderers, respectively).
+
+#### `env`
+
+`env` always has the following properties:
+
+  * `name` [string] - the name of the card
+  * `onTeardown` [function] - The atom can pass a callback function: `onTeardown(callbackFn)`. The callback will be called when the rendered content is torn down.
+
+## Atom Examples
+
+Example dom atom that renders a mention:
+
+```js
+export default {
+  name: 'mention',
+  type: 'dom',
+  render({ env, options, value, payload}) {
+    return document.createTextNode(`@${value}`);
+  }
+};
+```
+
+Example dom atom that registers a teardown callback:
+```js
+let card = {
+ name: 'atom-with-teardown-callback',
+ type: 'dom',
+ render({env, options, value, payload}) {
+   env.onTeardown(() => {
+    console.log('tearing down atom named: ' + env.name);
+   });
+ }
+};
+```

--- a/CARDS.md
+++ b/CARDS.md
@@ -53,33 +53,6 @@ When being rendered by an editor (i.e., `env.isInEditor` is true), the env will 
   * `remove` [function] - Removes this card from the document
   * `postModel` [object] - The instance of this card's section in the editor's internal abstract tree. This can be used along with the mobiledoc-kit `postEditor` API to transform the card in other ways (for example, moving the card to a different section of the document)
 
-## Renderers
-
-All of the officially-supported mobiledoc renderers have the same signature and methods.
-To instantiate a renderer, call its constructor with an object of options that has any of the following optional properties:
-
-  * `cards` [array] - The cards that your mobiledoc includes and that the renderer will encounter
-  * `cardOptions` [object] - Options to be passed to the card `render` (or `edit`) function
-  * `unknownCardHandler` [function] - This function is called (with the same arguments as `render`) whenever the renderer encounters a card that doesn't
-    match one of the `cards` it has been provided
-
-An instance of a renderer has one method, `render`. This method accepts a mobiledoc and returns an object with two properties:
-  * `result` [mixed] - The rendered result. Its type depends on the renderer, and can be a DOM Node (dom renderer) or a string (html or text renderers)
-  * `teardown` [function] - Call this function to tear down the rendered mobiledoc. The dom renderer will remove the rendered dom from the screen. All renderers will call
-    the card teardown callbacks that were registered using `env.onTeardown(callbackFunction)`
-
-Example usage of a renderer:
-```js
-let renderer = new DOMRenderer({cards: [card1, card2], cardOptions: {foo: 'bar'});
-let rendered = renderer.render(mobiledoc);
-
-document.body.appendChild(renderered.result);
-
-// later...
-
-rendered.teardown(); // removes the rendered items, calls teardown hooks
-```
-
 ## Card examples
 
 Example dom card that renders an image:

--- a/MOBILEDOC.md
+++ b/MOBILEDOC.md
@@ -22,92 +22,152 @@ prescription for output display.
 Often Mobiledoc will be used with one or more of:
 
 * [Mobiledoc Kit](https://github.com/bustlelabs/mobiledoc-kit) to author an editor
-  * [Ember Mobiledoc Editor](https://github.com/bustlelabs/ember-mobiledoc-editor) is one such editor 
+  * [Ember Mobiledoc Editor](https://github.com/bustlelabs/ember-mobiledoc-editor) is one such editor
 * [Mobiledoc DOM Renderer](https://github.com/bustlelabs/mobiledoc-dom-renderer)
 * [Mobiledoc HTML Renderer](https://github.com/bustlelabs/mobiledoc-html-renderer)
 * [Mobiledoc Text Renderer](https://github.com/bustlelabs/mobiledoc-text-renderer)
 
 ## Specification
 
-Mobiledoc consists of a wrapping object and nested array of section data. Using
-arrays makes Mobiledocs each to render quickly.
+Mobiledoc consists of a wrapping object, type definitions for markup, atoms and cards,
+and an array of section data. Using arrays makes Mobiledocs each to render quickly.
 
 The wrapper signature:
 
 ```
 {
-  version: "0.1",                         ──── Versioning information
-  sections: [
-    [                                     ──── List of markup types.
-      markup,
-      markup
-    ],
-    [                                     ──── List of sections.
-      section,
-      section,
-      section
-    ]
+  version: "0.3",                         ──── Versioning information
+  markups: [                              ──── List of markup types
+    markup,
+    markup
+  ],
+  atoms: [                                ──── List of atom types
+    atom,
+    atom
+  ],
+  cards: [                                ──── List of card types
+    card,
+    card
+  ],
+  sections: [                             ──── List of sections.
+    section,
+    section,
+    section
   ]
 }
 ```
 
-**Markup signature**
+**Markup definition signature**
+
+Markups have a tagName, and optionally an array of `attributeName, attributeValue]` pairs
 
 ```
 {
-  version: "0.1",
-  sections: [
+  version: "0.3",
+  markups: [
     [tagName, optionalAttributes],        ──── Markup
     ['em'],                               ──── Example simple markup
     ['a', ['href', 'http://google.com']], ──── Example markup with attributes
-  ],[
-    // ...
-  ]]
+  ]
 }
 ```
 
-**Text Section**
+**Atom definition signature**
+
+Atoms have a name, text value and arbitrary payload.
 
 ```
 {
-  version: "0.1",
-  sections: [[
-    ["b"],                                ──── Markup at index 0
-    ["i"]                                 ──── Markup at index 1
-  ],[
-    [typeIdentifier, tagName, markers],   ──── typeIdentifier for text sections
-    [1, "h2", [                                is always 1.
-      [[], 0, "Simple h2 example"],
-    ]],
-    [1, "p", [
-      [openMarkupsIndexes, numberOfClosedMarkups, value],
-      [[], 0, "Example with no markup"],
-      [[0], 1, "Example wrapped in b tag"],
-      [[1], 0, "Example opening i tag"],
-      [[], 1, "Example closing i tag"],
-      [[1, 0], 1, "Example opening i tag and b tag, closing b tag"],
-      [[], 1, "Example closing b tag"]
-    ]]
-  ]]
+  version: "0.3",
+  atoms: [
+    [atomName, atomText, atomPayload],    ──── Atom
+    ['mention', '@bob', { id: 42 }]       ──── Example 'mention' atom
+  ]
 }
 ```
 
-The first item in the `sections` array is a list of markups. Markups have
-a tagName, and optionally an array of `attributeName, attributeValue]` pairs.
+**Card definition signature**
+
+Cards have a name and arbitrary payload.
+
+```
+{
+  version: "0.3",
+  cards: [
+    [cardName, cardPayload],            ──── Card
+    ['image', {                         ──── Example 'image' card
+      src: 'http://google.com/logo.png'
+    }]
+  ]
+}
+```
+
+**Markup Section**
+
+Markup sections, in addition to plain text, can include markups and atoms.
+
+```
+{
+  version: "0.3",
+  markups: [
+    ["b"],                                ──── Markup at index 0
+    ["i"]                                 ──── Markup at index 1
+  ],
+  atoms: [
+    ["mention", "@bob", { id: 42 }]       ──── mention Atom at index 0
+    ["mention", "@tom", { id: 12 }]       ──── mention Atom at index 1
+  ]
+  sections: [
+    [sectionTypeIdentifier, tagName, markers],   ──── sectionTypeIdentifier for markup sections
+    [1, "h2", [                                       is always 1.
+      [0, [], 0, "Simple h2 example"],
+    ]],
+    [1, "p", [
+      [textTypeIdentifier, openMarkupsIndexes, numberOfClosedMarkups, value],
+      [0, [], 0, "Example with no markup"],      ──── textTypeIdentifier for markup is always 0
+      [0, [0], 1, "Example wrapped in b tag"],
+      [0, [1], 0, "Example opening i tag"],
+      [0, [], 1, "Example closing i tag"],
+      [0, [1, 0], 1, "Example opening i tag and b tag, closing b tag"],
+      [0, [], 1, "Example closing b tag"],
+    ]],
+    [1, "p", [
+      [textTypeIdentifier, atomIndex, openMarkupsIndexes, numberOfClosedMarkups],
+      [1, 0, [], 0],                                    ──── mention atom at index 0 (@bob), textTypeIdentifier for atom is always 1
+      [1, 1, [0], 1]                                    ──── mention atom at index 1 (@tom) wrapped in b tag
+    ]],
+  ]
+}
+```
+
 The index in `openMarkupsIndex` specifies which markups should be opened at
 the start of the `value` text. As these tags are opened, then create a stack
 of opened markups. The `numberOfClosedMarkups` says how many markups should
 be closed at the end of a `value`.
 
+In addition to markups, markup sections may contain [ATOMS](ATOMS.md).
+Atoms have a `textTypeIdentifier` of 1 and contain a `atomTypeIndex`, text content
+and an `atomPayload` object which is arbitrary and passed through to the atom's
+implementation.
+
+Atoms also have `openMarkupsIndex` and `numberOfClosedMarkups` so that markup can flow
+across them.
+
+If an atom is present in Mobiledoc, but no atom implementation is registered, then the text
+value of the atom will be rendered as plain text as a fallback.
+
 **Card Section**
 
 ```
 {
-  version: "0.1",
-  sections: [[],[
-    [typeIdentifier, tagName, markers],   ──── typeIdentifier for card sections
-    [10, "card-name", cardPayload]             is always 10.
-  ]]
+  version: "0.3",
+  cards: [
+    ["card-name", { cardPayload }]
+  ],
+  sections: [
+    [typeIdentifier, cardIndex],                 ──── typeIdentifier for card sections
+    [10, 0]                                           is always 10.
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ supporting rich content via cards.
   platform. Mobiledoc is portable and fast.
 * The editor makes limited use of Content Editable, the siren-song of doomed
   web editor technologies.
-* Mobiledoc is designed for *rich* content. We call these sections of an
-  article "cards", and implementing a new one doesn't require an understanding
-  of Mobiledoc editor internals. Adding a new card takes an afternoon, not several
-  days. To learn more about cards and mobiledoc renderers, see the **[Cards docs](https://github.com/bustlelabs/mobiledoc-kit/blob/master/CARDS.md)**.
+* Mobiledoc is designed for *rich* content. We call rich sections of an
+  article "cards" and rich inline elements "atoms" and implementing a new one doesn't require an understanding
+  of Mobiledoc editor internals. Adding a new atom or card takes an afternoon, not several
+  days. To learn more, see the docs for
+  **[Atoms](https://github.com/bustlelabs/mobiledoc-kit/blob/master/ATOMS.md)**,
+  **[Cards](https://github.com/bustlelabs/mobiledoc-kit/blob/master/CARDS.md)**
+  and
+  **[Mobiledoc Renderers](https://github.com/bustlelabs/mobiledoc-kit/blob/master/RENDERERS.md)**
 
 To learn more about the ideas behind Mobiledoc and the editor (note that the
 editor used to be named Content-Kit), see these blog posts:
@@ -55,7 +59,7 @@ editor.render(element);
 * `spellcheck` - [boolean] whether to enable spellcheck. Defaults to true.
 * `autofocus` - [boolean] When true, focuses on the editor when it is rendered.
 * `cards` - [array] The list of cards that the editor may render
-* `cardOptions` - [object] Options passed to 
+* `cardOptions` - [object] Options passed to cards and atoms
 * `unknownCardHandler` - [function] This will be invoked by the editor-renderer whenever it encounters an unknown card
 
 ### Editor API
@@ -132,10 +136,19 @@ It is important that you make changes to posts, sections, and markers through
 the `run` and `postEditor` API. This API allows the Mobiledoc editor to conserve
 and better understand changes being made to the post.
 
+```js
+editor.run(postEditor => {
+  const mention = postEditor.builder.createAtom("mention", "John Doe", { id: 42 });
+  // insert at current cursor position:
+  // or should the user have to grab the current position from the editor first?
+  postEditor.insertMarkers(editor.range.head, [mention]);
+});
+```
+
 For more details on the API of `postEditor`, see the [API documentation](https://github.com/bustlelabs/mobiledoc-kit/blob/master/src/js/editor/post.js).
 
 For more details on the API for the builder, required to create new sections
-and markers, see the [builder API](https://github.com/bustlelabs/mobiledoc-kit/blob/master/src/js/models/post-node-builder.js).
+atoms, and markers, see the [builder API](https://github.com/bustlelabs/mobiledoc-kit/blob/master/src/js/models/post-node-builder.js).
 
 ### Configuring hot keys
 

--- a/RENDERERS.md
+++ b/RENDERERS.md
@@ -1,0 +1,29 @@
+# Renderers
+
+All of the officially-supported mobiledoc renderers have the same signature and methods.
+To instantiate a renderer, call its constructor with an object of options that has any of the following optional properties:
+
+  * `atoms` [array] - The atoms that your mobiledoc includes and that the renderer will encounter
+  * `cards` [array] - The cards that your mobiledoc includes and that the renderer will encounter
+  * `cardOptions` [object] - Options to be passed to the card `render` (or `edit`) function and atoms `render` function
+  * `unknownAtomHandler` [function] - This function is called (with the same arguments as `render`) whenever the renderer encounters an atom that doesn't
+    match one of the `atoms` it has been provided
+  * `unknownCardHandler` [function] - This function is called (with the same arguments as `render`) whenever the renderer encounters a card that doesn't
+    match one of the `cards` it has been provided
+
+An instance of a renderer has one method, `render`. This method accepts a mobiledoc and returns an object with two properties:
+  * `result` [mixed] - The rendered result. Its type depends on the renderer, and can be a DOM Node (dom renderer) or a string (html or text renderers)
+  * `teardown` [function] - Call this function to tear down the rendered mobiledoc. The dom renderer will remove the rendered dom from the screen. All renderers will call
+    the card teardown callbacks that were registered using `env.onTeardown(callbackFunction)`
+
+Example usage of a renderer:
+```js
+let renderer = new DOMRenderer({atoms: [atom1, atom2], cards: [card1, card2], cardOptions: {foo: 'bar'});
+let rendered = renderer.render(mobiledoc);
+
+document.body.appendChild(renderered.result);
+
+// later...
+
+rendered.teardown(); // removes the rendered items, calls teardown hooks
+```

--- a/demo/app/components/mobiledoc-dom-renderer.js
+++ b/demo/app/components/mobiledoc-dom-renderer.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import cards from '../mobiledoc-cards/dom';
+import atoms from '../mobiledoc-atoms/dom';
 import Renderer from 'ember-mobiledoc-dom-renderer';
 
-let renderer = new Renderer({cards});
+let renderer = new Renderer({cards, atoms});
 
 export default Ember.Component.extend({
   didRender() {

--- a/demo/app/components/mobiledoc-html-renderer.js
+++ b/demo/app/components/mobiledoc-html-renderer.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import cards from '../mobiledoc-cards/html';
+import atoms from '../mobiledoc-atoms/html';
 import Renderer from 'ember-mobiledoc-html-renderer';
 
-let renderer = new Renderer({cards});
+let renderer = new Renderer({cards, atoms});
 
 export default Ember.Component.extend({
   didRender() {

--- a/demo/app/components/mobiledoc-text-renderer.js
+++ b/demo/app/components/mobiledoc-text-renderer.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import cards from '../mobiledoc-cards/text';
+import atoms from '../mobiledoc-atoms/text';
 import Renderer from 'ember-mobiledoc-text-renderer';
 
-let renderer = new Renderer({cards});
+let renderer = new Renderer({cards, atoms});
 
 let addHTMLEntitites = (str) => {
   return str.replace(/</g,  '&lt;')

--- a/demo/app/controllers/index.js
+++ b/demo/app/controllers/index.js
@@ -7,7 +7,7 @@ let { $ } = Ember;
 export default Ember.Controller.extend({
   init() {
     this._super.apply(this, arguments);
-    let mobiledoc = mobiledocs['simple'];
+    let mobiledoc = mobiledocs['mentionAtom'];
     this.set('mobiledoc', mobiledoc);
     this.set('editedMobiledoc', mobiledoc);
     this.set('rendererName', 'dom');

--- a/demo/app/helpers/mobiledoc-atoms-list.js
+++ b/demo/app/helpers/mobiledoc-atoms-list.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import atoms from '../mobiledoc-atoms/dom';
+
+export function mobiledocAtomsList() {
+  return atoms;
+}
+
+export default Ember.Helper.helper(mobiledocAtomsList);

--- a/demo/app/mobiledoc-atoms/dom.js
+++ b/demo/app/mobiledoc-atoms/dom.js
@@ -1,0 +1,7 @@
+import mentionAtom from './dom/mention';
+import imageAtom from './dom/image';
+
+export default [
+  mentionAtom,
+  imageAtom
+];

--- a/demo/app/mobiledoc-atoms/dom/image.js
+++ b/demo/app/mobiledoc-atoms/dom/image.js
@@ -1,0 +1,10 @@
+export default {
+  name: 'image-atom',
+  type: 'dom',
+  render() {
+    const element = document.createElement("img");
+    element.style.display = 'inline';
+    element.src = 'http://placehold.it/30x20';
+    return element;
+  }
+};

--- a/demo/app/mobiledoc-atoms/dom/mention.js
+++ b/demo/app/mobiledoc-atoms/dom/mention.js
@@ -1,0 +1,10 @@
+export default {
+  name: 'mention-atom',
+  type: 'dom',
+  render({value}) {
+    const element = document.createElement("span");
+    element.className = 'mention-atom';
+    element.appendChild(document.createTextNode(`Hello ${value}`));
+    return element;
+  }
+};

--- a/demo/app/mobiledoc-atoms/html.js
+++ b/demo/app/mobiledoc-atoms/html.js
@@ -1,0 +1,7 @@
+import mentionAtom from './html/mention';
+import imageAtom from './html/image';
+
+export default [
+  mentionAtom,
+  imageAtom
+];

--- a/demo/app/mobiledoc-atoms/html/image.js
+++ b/demo/app/mobiledoc-atoms/html/image.js
@@ -1,0 +1,7 @@
+export default {
+  name: 'image-atom',
+  type: 'html',
+  render({value}) {
+    return `<img src="${value}">`;
+  }
+};

--- a/demo/app/mobiledoc-atoms/html/mention.js
+++ b/demo/app/mobiledoc-atoms/html/mention.js
@@ -1,0 +1,7 @@
+export default {
+  name: 'mention-atom',
+  type: 'html',
+  render({value}) {
+    return `<span class="mention-atom">Hello ${value}</span>`;
+  }
+};

--- a/demo/app/mobiledoc-atoms/text.js
+++ b/demo/app/mobiledoc-atoms/text.js
@@ -1,0 +1,5 @@
+import mentionAtom from './text/mention';
+
+export default [
+  mentionAtom
+];

--- a/demo/app/mobiledoc-atoms/text/mention.js
+++ b/demo/app/mobiledoc-atoms/text/mention.js
@@ -1,0 +1,7 @@
+export default {
+  name: 'mention-atom',
+  type: 'text',
+  render({value}) {
+    return `Hello ${value}`;
+  }
+};

--- a/demo/app/mobiledocs/index.js
+++ b/demo/app/mobiledocs/index.js
@@ -1,102 +1,154 @@
 export default {
-  codemirrorCard: {
-    version: '0.2.0',
+  mentionAtom: {
+    version: '0.3.0',
+    atoms: [
+      ['mention-atom', 'Bob', {}],
+      ['mention-atom', 'Bob', {}],
+      ['mention-atom', 'Bob', {}],
+      ['mention-atom', 'Bob', {}],
+      ['mention-atom', 'Bob', {}],
+      ['mention-atom', 'Bob', {}],
+      ['mention-atom', 'Bob', {}],
+      ['image-atom', 'n/a', {}]
+    ],
+    markups: [],
+    cards: [],
     sections: [
-      [],
-      [
-        [1, 'h2', [
-          [[], 0, 'Codemirror']
-        ]],
-        [10, 'codemirror-card'],
-      ]
+      [1, 'h2', [
+        [0, [], 0, 'Mention Atom']
+      ]],
+      [1, 'P', [
+        [0, [], 0, 'Text before the atom. '],
+        [1, [], 0, 0],
+        [0, [], 0, ' Text after the atom, before image: '],
+        [1, [], 0, 7],
+        [0, [], 0, ' text after the image atom']
+      ]],
+      [1, 'P', [
+        [1, [], 0, 1],
+        [0, [], 0, ' atom at start']
+      ]],
+      [1, 'P', [
+        [0, [], 0, 'atom at end '],
+        [1, [], 0, 2]
+      ]],
+      [1, 'P', [
+        [1, [], 0, 3],
+        [1, [], 0, 4],
+        [0, [], 0, ' multiple atoms at start and end '],
+        [1, [], 0, 5],
+        [1, [], 0, 6]
+      ]]
     ]
   },
-  empty: {
-    version: '0.2.0',
+  codemirrorCard: {
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [
+      ['codemirror-card']
+    ],
     sections: [
-      [],
-      []
+      [1, 'h2', [
+        [0, [], 0, 'Codemirror']
+      ]],
+      [10, 0],
     ]
   },
   'null': null,
   blank: '',
+  empty: {
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [],
+    sections: []
+  },
   inputCard: {
-    version: '0.2.0',
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [
+      ['input-card']
+    ],
     sections: [
-      [],
-      [
-        [1, 'H2', [
-          [[], 0, 'Input Card']
-        ]],
-        [10, 'input-card'],
-        [1, 'P', [
-          [[], 0, 'Text after the card.']
-        ]]
-      ]
+      [1, 'H2', [
+        [0, [], 0, 'Input Card']
+      ]],
+      [10, 0],
+      [1, 'P', [
+        [0, [], 0, 'Text after the card.']
+      ]]
     ]
   },
   imageCard: {
-    version: '0.2.0',
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [
+      ['image-card']
+    ],
     sections: [
-      [],
-      [
-        [1, 'p', [[[], 0, 'before']]],
-        [10, 'image-card'],
-        [1, 'p', [[[], 0, 'after']]]
-      ]
+      [1, 'p', [[0, [], 0, 'before']]],
+      [10, 0],
+      [1, 'p', [[0, [], 0, 'after']]]
     ]
   },
   selfieCard: {
-    version: '0.2.0',
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [
+      ['selfie-card']
+    ],
     sections: [
-      [],
-      [
-        [1, 'H2', [
-          [[], 0, 'Selfie Card']
-        ]],
-        [10, 'selfie-card']
-      ]
+      [1, 'H2', [
+        [0, [], 0, 'Selfie Card']
+      ]],
+      [10, 0]
     ]
   },
   simpleCard: {
-    version: '0.2.0',
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [
+      ['simple-card']
+    ],
     sections: [
-      [],
-      [
-        [1, 'p', [[[], 0, 'before']]],
-        [10, 'simple-card'],
-        [1, 'p', [[[], 0, 'after']]]
-      ]
+      [1, 'p', [[0, [], 0, 'before']]],
+      [10, 0],
+      [1, 'p', [[0, [], 0, 'after']]]
     ]
   },
   simpleList: {
-    version: '0.2.0',
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [],
     sections: [
-      [],
-      [
-        [1, 'H2', [
-          [[], 0, 'To do today:']
-        ]],
-        [3, 'ul', [
-          [[[], 0, 'buy milk']],
-          [[[], 0, 'water plants']],
-          [[[], 0, 'world domination']]
-        ]]
-      ]
+      [1, 'H2', [
+        [0, [], 0, 'To do today:']
+      ]],
+      [3, 'ul', [
+        [[0, [], 0, 'buy milk']],
+        [[0, [], 0, 'water plants']],
+        [[0, [], 0, 'world domination']]
+      ]]
     ]
   },
   simple: {
-    version: '0.2.0',
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [],
     sections: [
-      [],
-      [
-        [1, 'H2', [
-          [[], 0, 'Hello World']
-        ]],
-        [1, 'p', [
-          [[], 0, 'This is Mobiledoc-kit.']
-        ]]
-      ]
+      [1, 'H2', [
+        [0, [], 0, 'Hello World']
+      ]],
+      [1, 'p', [
+        [0, [], 0, 'This is Mobiledoc-kit.']
+      ]]
     ]
   },
   emberCard: {

--- a/demo/app/styles/app.css
+++ b/demo/app/styles/app.css
@@ -242,3 +242,12 @@ hr {
   font-weight: bold;
   background-color: aliceblue;
 }
+
+.mention-atom {
+  background-color: #CCC;
+  border-radius: 5px;
+  color: #FFF;
+  padding: 0 5px;
+  font-size: 0.75em;
+}
+

--- a/demo/app/templates/index.hbs
+++ b/demo/app/templates/index.hbs
@@ -29,11 +29,13 @@
         <option value='inputCard'>Card with Input</option>
         <option value='selfieCard'>Selfie Card</option>
         <option value='codemirrorCard'>Codemirror Card</option>
+        <option value='mentionAtom'>Mention Atom</option>
       </select>
       {{#mobiledoc-editor
           class='post-editor__editor'
           mobiledoc=mobiledoc
           cards=(mobiledoc-cards-list)
+          atoms=(mobiledoc-atoms-list)
           on-change=(action 'didEdit')
         as |editor|}}
         <button {{action editor.addCardInEditMode 'image-card'}}>Add image</button>

--- a/demo/package.json
+++ b/demo/package.json
@@ -35,8 +35,8 @@
     "ember-mobiledoc-editor": "0.3.2-beta.5",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-mobiledoc-dom-renderer": "^0.2.1",
-    "ember-mobiledoc-html-renderer": "^0.2.0",
-    "ember-mobiledoc-text-renderer": "^0.2.0"
+    "ember-mobiledoc-dom-renderer": "^0.3.0-beta.1",
+    "ember-mobiledoc-html-renderer": "^0.3.0-beta.1",
+    "ember-mobiledoc-text-renderer": "^0.3.0-beta.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "mobiledoc-html-renderer": "^0.2.0",
-    "mobiledoc-text-renderer": "^0.2.0"
+    "mobiledoc-html-renderer": "0.3.0-beta1",
+    "mobiledoc-text-renderer": "0.3.0-beta1"
   },
   "devDependencies": {
     "broccoli": "^0.16.3",

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -51,9 +51,13 @@ const defaults = {
   spellcheck: true,
   autofocus: true,
   cards: [],
+  atoms: [],
   cardOptions: {},
   unknownCardHandler: ({env}) => {
     throw new Error(`Unknown card encountered: ${env.name}`);
+  },
+  unknownAtomHandler: ({env}) => {
+    throw new Error(`Unknown atom encountered: ${env.name}`);
   },
   mobiledoc: null,
   html: null
@@ -91,7 +95,7 @@ class Editor {
     DEFAULT_KEY_COMMANDS.forEach(kc => this.registerKeyCommand(kc));
 
     this._parser   = new DOMParser(this.builder);
-    this._renderer = new Renderer(this, this.cards, this.unknownCardHandler, this.cardOptions);
+    this._renderer = new Renderer(this, this.cards, this.atoms, this.unknownCardHandler, this.unknownAtomHandler, this.cardOptions);
 
     this.post = this.loadPost();
     this._renderTree = new RenderTree(this.post);
@@ -618,8 +622,12 @@ class Editor {
         if (range.direction === DIRECTION.BACKWARD) {
           position = range.head;
         }
-        if (position.section.isCardSection) {
-          nextPosition = position.move(key.direction);
+        nextPosition = position.move(key.direction);
+        if (
+          position.section.isCardSection ||
+          (position.marker && position.marker.isAtom) ||
+          (nextPosition && nextPosition.marker && nextPosition.marker.isAtom)
+        ) {
           if (nextPosition) {
             let newRange;
             if (key.isShift()) {
@@ -654,6 +662,7 @@ class Editor {
           if (!isCollapsed) {
             nextPosition = postEditor.deleteRange(range);
           }
+
           let isMarkerable = range.head.section.isMarkerable;
           if (isMarkerable &&
               (key.isTab() || key.isSpace())
@@ -661,6 +670,17 @@ class Editor {
             let toInsert = key.isTab() ? TAB : SPACE;
             shouldPreventDefault = true;
             nextPosition = postEditor.insertText(nextPosition, toInsert);
+          }
+
+          if (nextPosition.marker && nextPosition.marker.isAtom) {
+            // ensure that the cursor is properly repositioned one character forward
+            // after typing on either side of an atom
+            this.addCallbackOnce(CALLBACK_QUEUES.DID_REPARSE, () => {
+              let position = nextPosition.move(DIRECTION.FORWARD);
+              let nextRange = new Range(position);
+
+              this.run(postEditor => postEditor.setRange(nextRange));
+            });
           }
           if (nextPosition && nextPosition !== range.head) {
             postEditor.setRange(new Range(nextPosition));

--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -53,6 +53,26 @@ export const DEFAULT_KEY_COMMANDS = [{
     });
   }
 }, {
+  // FIXME restrict to OS X only?
+  str: 'CTRL+A',
+  run(editor) {
+    let range = editor.cursor.offsets;
+    let {head: {section}} = range;
+    editor.run(postEditor => {
+      postEditor.setRange(new Range(section.headPosition()));
+    });
+  }
+}, {
+  // FIXME restrict to OS X only?
+  str: 'CTRL+E',
+  run(editor) {
+    let range = editor.cursor.offsets;
+    let {tail: {section}} = range;
+    editor.run(postEditor => {
+      postEditor.setRange(new Range(section.tailPosition()));
+    });
+  }
+}, {
   str: 'META+K',
   run(editor) {
     if (!editor.cursor.hasSelection()) {

--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -3,7 +3,6 @@ import Set from '../utils/set';
 
 import LinkedList from '../utils/linked-list';
 import Section from './_section';
-import Position from '../utils/cursor/position';
 import assert from '../utils/assert';
 
 export default class Markerable extends Section {
@@ -13,8 +12,8 @@ export default class Markerable extends Section {
     this.tagName = tagName;
     this.markers = new LinkedList({
       adoptItem: m => {
-        assert(`Cannot insert non-marker into markerable (was: ${m.type})`,
-               m.isMarker);
+        assert(`Can only insert markers and atoms into markerable (was: ${m.type})`,
+               m.isMarker || m.isAtom);
         m.section = m.parent = this;
       },
       freeItem: m => m.section = m.parent = null
@@ -33,14 +32,6 @@ export default class Markerable extends Section {
     const newMarkers = this.markers.map(m => m.clone());
     return this.builder.createMarkerableSection(
       this.type, this.tagName, newMarkers);
-  }
-
-  headPosition() {
-    return new Position(this, 0);
-  }
-
-  tailPosition() {
-    return new Position(this, this.length);
   }
 
   get isBlank() {
@@ -82,7 +73,7 @@ export default class Markerable extends Section {
    * @return {Array} the new markers that replaced `marker`
    */
   splitMarker(marker, offset, endOffset=marker.length) {
-    const newMarkers = filter(marker.split(offset, endOffset), m => !m.isEmpty);
+    const newMarkers = filter(marker.split(offset, endOffset), m => !m.isBlank);
     this.markers.splice(marker, 1, newMarkers);
     return newMarkers;
   }
@@ -203,7 +194,7 @@ export default class Markerable extends Section {
   }
 
   get length() {
-    return this.text.length;
+    return reduce(this.markers, (prev, m) => prev + m.length, 0);
   }
 
   /**
@@ -215,9 +206,14 @@ export default class Markerable extends Section {
                    tail: {section:this, offset:tailOffset}};
 
     let markers = [];
-    this._markersInRange(range, (marker, {markerHead, markerTail}) => {
+    this._markersInRange(range, (marker, {markerHead, markerTail, isContained}) => {
       const cloned = marker.clone();
-      cloned.value = marker.value.slice(markerHead, markerTail);
+      if (!isContained) {
+        // cannot do marker.value.slice if the marker is an atom -- this breaks the atom's "atomic" value
+        // If a marker is an atom `isContained` should always be true so
+        // we shouldn't hit this code path. FIXME add tests
+        cloned.value = marker.value.slice(markerHead, markerTail);
+      }
       markers.push(cloned);
     });
     return markers;
@@ -266,7 +262,7 @@ export default class Markerable extends Section {
     let afterMarker = null;
 
     otherSection.markers.forEach(m => {
-      if (!m.isEmpty) {
+      if (!m.isBlank) {
         m = m.clone();
         this.markers.append(m);
         if (!afterMarker) {

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -1,6 +1,7 @@
 import { normalizeTagName } from '../utils/dom-utils';
 import LinkedItem from '../utils/linked-item';
 import assert from '../utils/assert';
+import Position from '../utils/cursor/position';
 
 function unimplementedMethod(methodName, me) {
   assert(`\`${methodName}()\` must be implemented by ${me.constructor.name}`,
@@ -47,11 +48,13 @@ export default class Section extends LinkedItem {
   }
 
   headPosition() {
-    unimplementedMethod('headPosition', this);
+    return new Position(this, 0);
   }
 
   tailPosition() {
-    unimplementedMethod('tailPosition', this);
+    assert('Cannot determine tailPosition without length',
+           this.length !== undefined && this.length !== null);
+    return new Position(this, this.length);
   }
 
   join() {

--- a/src/js/models/atom-node.js
+++ b/src/js/models/atom-node.js
@@ -1,0 +1,60 @@
+import assert from '../utils/assert';
+
+export default class AtomNode {
+  constructor(editor, atom, model, element, atomOptions) {
+    this.editor = editor;
+    this.atom = atom;
+    this.model = model;
+    this.atomOptions = atomOptions;
+    this.element = element;
+
+    this._teardownCallback = null;
+    this._rendered         = null;
+  }
+
+  render() {
+    this.teardown();
+
+    let rendered = this.atom.render({
+      options: this.atomOptions,
+      env: this.env,
+      value: this.model.value,
+      payload: this.model.payload
+    });
+
+    this._validateAndAppendRenderResult(rendered);
+  }
+
+  get env() {
+    return {
+      name: this.atom.name,
+      onTeardown: (callback) => this._teardownCallback = callback
+    };
+  }
+
+  teardown() {
+    if (this._teardownCallback) {
+      this._teardownCallback();
+      this._teardownCallback = null;
+    }
+    if (this._rendered) {
+      this.element.removeChild(this._rendered);
+      this._rendered = null;
+    }
+  }
+
+  _validateAndAppendRenderResult(rendered) {
+    if (!rendered) {
+      return;
+    }
+
+    let { atom: { name } } = this;
+    assert(
+      `Atom "${name}" must return a DOM node (returned value was: "${rendered}")`,
+      !!rendered.nodeType
+    );
+    this.element.appendChild(rendered);
+    this._rendered = rendered;
+  }
+
+}

--- a/src/js/models/atom.js
+++ b/src/js/models/atom.js
@@ -1,0 +1,82 @@
+import { ATOM_TYPE } from './types';
+import mixin from '../utils/mixin';
+import MarkuperableMixin from '../utils/markuperable';
+import LinkedItem from '../utils/linked-item';
+import assert from '../utils/assert';
+
+const ATOM_LENGTH = 1;
+
+export default class Atom extends LinkedItem {
+  constructor(name, value, payload, markups=[]) {
+    super();
+    this.name = name;
+    this.value = value;
+    this.payload = payload;
+    this.type = ATOM_TYPE;
+    this.isAtom = true;
+
+    this.markups = [];
+    markups.forEach(m => this.addMarkup(m));
+  }
+
+  clone() {
+    let clonedMarkups = this.markups.slice();
+    return this.builder.createAtom(
+      this.name, this.value, this.payload, clonedMarkups
+    );
+  }
+
+  get isBlank() {
+    return false;
+  }
+
+  get length() {
+    return ATOM_LENGTH;
+  }
+
+  canJoin(/* other */) {
+    return false;
+  }
+
+  split(offset=0, endOffset=1) {
+    let markers = [];
+
+    if (endOffset === 0) {
+      markers.push(this.builder.createMarker('', this.markups.slice()));
+    }
+
+    markers.push(this.clone());
+
+    if (offset === ATOM_LENGTH) {
+      markers.push(this.builder.createMarker('', this.markups.slice()));
+    }
+
+    return markers;
+  }
+
+  splitAtOffset(offset) {
+    assert('Cannot split a marker at an offset > its length',
+           offset <= this.length);
+
+    let { builder } = this;
+    let clone = this.clone();
+    let blankMarker = builder.createMarker('');
+    let pre, post;
+
+    if (offset === 0) {
+      ([pre, post] = [clone, blankMarker]);
+    } else if (offset === ATOM_LENGTH) {
+      ([pre, post] = [blankMarker, clone]);
+    } else {
+      assert(`Invalid offset given to Atom#splitAtOffset: "${offset}"`, false);
+    }
+
+    this.markups.forEach(markup => {
+      pre.addMarkup(markup);
+      post.addMarkup(markup);
+    });
+    return [pre, post];
+  }
+}
+
+mixin(Atom, MarkuperableMixin);

--- a/src/js/models/card.js
+++ b/src/js/models/card.js
@@ -1,7 +1,6 @@
 import Section from './_section';
 import { CARD_TYPE } from './types';
 import { shallowCopyObject } from '../utils/copy';
-import Position from '../utils/cursor/position';
 
 export const CARD_MODES = {
   DISPLAY: 'display',
@@ -17,7 +16,6 @@ export default class Card extends Section {
     this.payload = payload;
     this.setInitialMode(DEFAULT_INITIAL_MODE);
     this.isCardSection = true;
-    this.length = 1;
   }
 
   get isBlank() {
@@ -28,12 +26,8 @@ export default class Card extends Section {
     return false;
   }
 
-  headPosition() {
-    return new Position(this, 0);
-  }
-
-  tailPosition() {
-    return new Position(this, 1);
+  get length() {
+    return 1;
   }
 
   clone() {

--- a/src/js/models/image.js
+++ b/src/js/models/image.js
@@ -1,6 +1,5 @@
 import { IMAGE_SECTION_TYPE } from './types';
 import Section from './_section';
-import Position from '../utils/cursor/position';
 
 export default class Image extends Section {
   constructor() {
@@ -12,11 +11,7 @@ export default class Image extends Section {
     return false;
   }
 
-  headPosition() {
-    return new Position(this, 0);
-  }
-
-  tailPosition() {
-    return new Position(this, 1);
+  get length() {
+    return 1;
   }
 }

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -1,3 +1,4 @@
+import Atom from '../models/atom';
 import Post from '../models/post';
 import MarkupSection from '../models/markup-section';
 import ListSection from '../models/list-section';
@@ -100,6 +101,12 @@ export default class PostNodeBuilder {
     const marker = new Marker(value, markups);
     marker.builder = this;
     return marker;
+  }
+
+  createAtom(name, text, payload={}, markups=[]) {
+    const atom = new Atom(name, text, payload, markups);
+    atom.builder = this;
+    return atom;
   }
 
   /**

--- a/src/js/models/render-node.js
+++ b/src/js/models/render-node.js
@@ -16,6 +16,14 @@ export default class RenderNode extends LinkedItem {
 
     // RenderNodes for Markers keep track of their markupElement
     this.markupElement = null;
+
+    // RenderNodes for Atoms use these properties
+    this.headTextNode = null;
+    this.tailTextNode = null;
+    this.atomNode = null;
+
+    // RenderNodes for cards use this property
+    this.cardNode = null;
   }
   isAttached() {
     assert('Cannot check if a renderNode is attached without an element.',

--- a/src/js/models/types.js
+++ b/src/js/models/types.js
@@ -6,3 +6,4 @@ export const POST_TYPE = 'post';
 export const LIST_ITEM_TYPE = 'list-item';
 export const CARD_TYPE = 'card-section';
 export const IMAGE_SECTION_TYPE = 'image-section';
+export const ATOM_TYPE = 'atom';

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -1,6 +1,7 @@
 import {
   NO_BREAK_SPACE,
-  TAB_CHARACTER
+  TAB_CHARACTER,
+  ATOM_CLASS_NAME
 } from '../renderers/editor-dom';
 import {
   MARKUP_SECTION_TYPE,
@@ -10,6 +11,8 @@ import {
 import {
   isTextNode,
   isCommentNode,
+  isElementNode,
+  getAttributes,
   normalizeTagName
 } from '../utils/dom-utils';
 import {
@@ -17,9 +20,9 @@ import {
   forEach
 } from '../utils/array-utils';
 import { TAB } from 'mobiledoc-kit/utils/characters';
+import { ZWNJ } from 'mobiledoc-kit/renderers/editor-dom';
 
 import SectionParser from 'mobiledoc-kit/parsers/section';
-import { getAttributes, walkTextNodes } from '../utils/dom-utils';
 import Markup from 'mobiledoc-kit/models/markup';
 
 const GOOGLE_DOCS_CONTAINER_ID_REGEX = /^docs\-internal\-guid/;
@@ -64,6 +67,26 @@ function remapTagName(tagName) {
 
 function trim(str) {
   return str.replace(/^\s+/, '').replace(/\s+$/, '');
+}
+
+function walkMarkerableNodes(parent, callback) {
+  let currentNode = parent;
+
+  if (
+    isTextNode(currentNode) ||
+    (
+      isElementNode(currentNode) &&
+      currentNode.classList.contains(ATOM_CLASS_NAME)
+    )
+  ) {
+    callback(currentNode);
+  } else {
+    currentNode = currentNode.firstChild;
+    while (currentNode) {
+      walkMarkerableNodes(currentNode, callback);
+      currentNode = currentNode.nextSibling;
+    }
+  }
 }
 
 /**
@@ -169,46 +192,101 @@ export default class DOMParser {
   }
 
   _reparseSectionContainingMarkers(section, renderTree) {
-    const element = section.renderNode.element;
+    let element = section.renderNode.element;
     let seenRenderNodes = [];
     let previousMarker;
 
-    walkTextNodes(element, (textNode) => {
-      const text = transformHTMLText(textNode.textContent);
-      let markups = this.collectMarkups(textNode, element);
-
+    walkMarkerableNodes(element, (node) => {
       let marker;
-
-      let renderNode = renderTree.getElementRenderNode(textNode);
+      let renderNode = renderTree.getElementRenderNode(node);
       if (renderNode) {
-        if (text.length) {
-          marker = renderNode.postNode;
-          marker.value = text;
-          marker.markups = markups;
-        } else {
-          renderNode.scheduleForRemoval();
+        if (renderNode.postNode.isMarker) {
+          let text = transformHTMLText(node.textContent);
+          let markups = this.collectMarkups(node, element);
+          if (text.length) {
+            marker = renderNode.postNode;
+            marker.value = text;
+            marker.markups = markups;
+          } else {
+            renderNode.scheduleForRemoval();
+          }
+        } else if (renderNode.postNode.isAtom) {
+          let { headTextNode, tailTextNode } = renderNode;
+          if (headTextNode.textContent !== ZWNJ) {
+            let value = headTextNode.textContent.replace(new RegExp(ZWNJ, 'g'), '');
+            headTextNode.textContent = ZWNJ;
+            if (previousMarker && previousMarker.isMarker) {
+              previousMarker.value += value;
+              if (previousMarker.renderNode) {
+                previousMarker.renderNode.markDirty();
+              }
+            } else {
+              let postNode = renderNode.postNode;
+              let newMarkups = postNode.markups.slice();
+              let newPreviousMarker = this.builder.createMarker(value, newMarkups);
+              section.markers.insertBefore(newPreviousMarker, postNode);
+
+              let newPreviousRenderNode = renderTree.buildRenderNode(newPreviousMarker);
+              newPreviousRenderNode.markDirty();
+              section.renderNode.markDirty();
+
+              seenRenderNodes.push(newPreviousRenderNode);
+              section.renderNode.childNodes.insertBefore(newPreviousRenderNode,
+                                                         renderNode);
+            }
+          }
+          if (tailTextNode.textContent !== ZWNJ) {
+            let value = tailTextNode.textContent.replace(new RegExp(ZWNJ, 'g'), '');
+            tailTextNode.textContent = ZWNJ;
+
+            if (renderNode.postNode.next && renderNode.postNode.next.isMarker) {
+              let nextMarker = renderNode.postNode.next;
+
+              if (nextMarker.renderNode) {
+                let nextValue = nextMarker.renderNode.element.textContent;
+                nextMarker.renderNode.element.textContent = value + nextValue;
+              } else {
+                let nextValue = value + nextMarker.value;
+                nextMarker.value = nextValue;
+              }
+            } else {
+              let postNode = renderNode.postNode;
+              let newMarkups = postNode.markups.slice();
+              let newMarker = this.builder.createMarker(value, newMarkups);
+
+              section.markers.insertAfter(newMarker, postNode);
+
+              let newRenderNode = renderTree.buildRenderNode(newMarker);
+              seenRenderNodes.push(newRenderNode);
+
+              newRenderNode.markDirty();
+              section.renderNode.markDirty();
+
+              section.renderNode.childNodes.insertAfter(newRenderNode, renderNode);
+            }
+          }
+          if (renderNode) {
+            marker = renderNode.postNode;
+          }
         }
-      } else {
+      } else if (isTextNode(node)) {
+        let text = transformHTMLText(node.textContent);
+        let markups = this.collectMarkups(node, element);
         marker = this.builder.createMarker(text, markups);
 
         renderNode = renderTree.buildRenderNode(marker);
-        renderNode.element = textNode;
+        renderNode.element = node;
         renderNode.markClean();
         section.renderNode.markDirty();
 
         let previousRenderNode = previousMarker && previousMarker.renderNode;
         section.markers.insertAfter(marker, previousMarker);
         section.renderNode.childNodes.insertAfter(renderNode, previousRenderNode);
-
-        let parentNodeCount = marker.closedMarkups.length;
-        let nextMarkerElement = textNode.parentNode;
-        while (parentNodeCount--) {
-          nextMarkerElement = nextMarkerElement.parentNode;
-        }
-        renderNode.nextMarkerElement = nextMarkerElement;
       }
 
-      seenRenderNodes.push(renderNode);
+      if (renderNode) {
+        seenRenderNodes.push(renderNode);
+      }
       previousMarker = marker;
     });
 

--- a/src/js/parsers/mobiledoc/0-2.js
+++ b/src/js/parsers/mobiledoc/0-2.js
@@ -86,7 +86,7 @@ export default class MobiledocParser {
     this.parseMarkers(markers, section);
     // Strip blank markers after the have been created. This ensures any
     // markup they include has been correctly populated.
-    filter(section.markers, m => m.isEmpty).forEach(m => {
+    filter(section.markers, m => m.isBlank).forEach(m => {
       section.markers.remove(m);
     });
   }

--- a/src/js/parsers/mobiledoc/0-3.js
+++ b/src/js/parsers/mobiledoc/0-3.js
@@ -1,0 +1,169 @@
+import {
+  MOBILEDOC_MARKUP_SECTION_TYPE,
+  MOBILEDOC_IMAGE_SECTION_TYPE,
+  MOBILEDOC_LIST_SECTION_TYPE,
+  MOBILEDOC_CARD_SECTION_TYPE,
+  MOBILEDOC_MARKUP_MARKER_TYPE,
+  MOBILEDOC_ATOM_MARKER_TYPE
+} from 'mobiledoc-kit/renderers/mobiledoc/0-3';
+import { kvArrayToObject, filter } from "../../utils/array-utils";
+
+/*
+ * Parses from mobiledoc -> post
+ */
+export default class MobiledocParser {
+  constructor(builder) {
+    this.builder = builder;
+  }
+
+  /**
+   * @method parse
+   * @param {Mobiledoc}
+   * @return {Post}
+   */
+  parse({ version, sections, markups: markerTypes, cards: cardTypes, atoms: atomTypes }) {
+    try {
+      const post = this.builder.createPost();
+
+      this.markups = [];
+      this.markerTypes = this.parseMarkerTypes(markerTypes);
+      this.cardTypes = this.parseCardTypes(cardTypes);
+      this.atomTypes = this.parseAtomTypes(atomTypes);
+      this.parseSections(sections, post);
+
+      return post;
+    } catch (e) {
+      throw new Error(`Unable to parse mobiledoc: ${e.message}`);
+    }
+  }
+
+  parseMarkerTypes(markerTypes) {
+    return markerTypes.map((markerType) => this.parseMarkerType(markerType));
+  }
+
+  parseMarkerType([tagName, attributesArray]) {
+    const attributesObject = kvArrayToObject(attributesArray || []);
+    return this.builder.createMarkup(tagName, attributesObject);
+  }
+
+  parseCardTypes(cardTypes) {
+    return cardTypes.map((cardType) => this.parseCardType(cardType));
+  }
+
+  parseCardType([cardName, cardPayload]) {
+    return [cardName, cardPayload];
+  }
+
+  parseAtomTypes(atomTypes) {
+    return atomTypes.map((atomType) => this.parseAtomType(atomType));
+  }
+
+  parseAtomType([atomName, atomValue, atomPayload]) {
+    return [atomName, atomValue, atomPayload];
+  }
+
+  parseSections(sections, post) {
+    sections.forEach((section) => this.parseSection(section, post));
+  }
+
+  parseSection(section, post) {
+    let [type] = section;
+    switch(type) {
+      case MOBILEDOC_MARKUP_SECTION_TYPE:
+        this.parseMarkupSection(section, post);
+        break;
+      case MOBILEDOC_IMAGE_SECTION_TYPE:
+        this.parseImageSection(section, post);
+        break;
+      case MOBILEDOC_CARD_SECTION_TYPE:
+        this.parseCardSection(section, post);
+        break;
+      case MOBILEDOC_LIST_SECTION_TYPE:
+        this.parseListSection(section, post);
+        break;
+      default:
+        throw new Error(`Unexpected section type ${type}`);
+    }
+  }
+
+  getAtomTypeFromIndex(index) {
+    const atomType = this.atomTypes[index];
+    if (!atomType) {
+      throw new Error(`No atom definition found at index ${index}`);
+    }
+    return atomType;
+  }
+
+  getCardTypeFromIndex(index) {
+    const cardType = this.cardTypes[index];
+    if (!cardType) {
+      throw new Error(`No card definition found at index ${index}`);
+    }
+    return cardType;
+  }
+
+  parseCardSection([type, cardIndex], post) {
+    const [name, payload] = this.getCardTypeFromIndex(cardIndex);
+    const section = this.builder.createCardSection(name, payload);
+    post.sections.append(section);
+  }
+
+  parseImageSection([type, src], post) {
+    const section = this.builder.createImageSection(src);
+    post.sections.append(section);
+  }
+
+  parseMarkupSection([type, tagName, markers], post) {
+    const section = this.builder.createMarkupSection(tagName);
+    post.sections.append(section);
+    this.parseMarkers(markers, section);
+    // Strip blank markers after the have been created. This ensures any
+    // markup they include has been correctly populated.
+    filter(section.markers, m => m.isBlank).forEach(m => {
+      section.markers.remove(m);
+    });
+  }
+
+  parseListSection([type, tagName, items], post) {
+    const section = this.builder.createListSection(tagName);
+    post.sections.append(section);
+    this.parseListItems(items, section);
+  }
+
+  parseListItems(items, section) {
+    items.forEach(i => this.parseListItem(i, section));
+  }
+
+  parseListItem(markers, section) {
+    const item = this.builder.createListItem();
+    this.parseMarkers(markers, item);
+    section.items.append(item);
+  }
+
+  parseMarkers(markers, parent) {
+    markers.forEach(m => this.parseMarker(m, parent));
+  }
+
+  parseMarker([type, markerTypeIndexes, closeCount, value], parent) {
+    markerTypeIndexes.forEach(index => {
+      this.markups.push(this.markerTypes[index]);
+    });
+
+    const marker = this.buildMarkerType(type, value);
+    parent.markers.append(marker);
+
+    this.markups = this.markups.slice(0, this.markups.length-closeCount);
+  }
+
+  buildMarkerType(type, value) {
+    switch (type) {
+      case MOBILEDOC_MARKUP_MARKER_TYPE:
+        return this.builder.createMarker(value, this.markups.slice());
+      case MOBILEDOC_ATOM_MARKER_TYPE:
+        const [atomName, atomValue, atomPayload] = this.getAtomTypeFromIndex(value);
+        return this.builder.createAtom(atomName, atomValue, atomPayload, this.markups.slice());
+      default:
+        throw new Error(`Unexpected marker type ${type}`);
+    }
+  }
+}

--- a/src/js/parsers/mobiledoc/index.js
+++ b/src/js/parsers/mobiledoc/index.js
@@ -1,5 +1,8 @@
 import MobiledocParser_0_2 from './0-2';
-import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
+import MobiledocParser_0_3 from './0-3';
+
+import { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2 } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
+import { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
 import assert from 'mobiledoc-kit/utils/assert';
 
 function parseVersion(mobiledoc) {
@@ -10,8 +13,10 @@ export default {
   parse(builder, mobiledoc) {
     let version = parseVersion(mobiledoc);
     switch (version) {
-      case MOBILEDOC_VERSION:
+      case MOBILEDOC_VERSION_0_2:
         return new MobiledocParser_0_2(builder).parse(mobiledoc);
+      case MOBILEDOC_VERSION_0_3:
+        return new MobiledocParser_0_3(builder).parse(mobiledoc);
       default:
         assert(`Unknown version of mobiledoc parser requested: ${version}`,
                false);

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -1,5 +1,6 @@
 import CardNode from 'mobiledoc-kit/models/card-node';
 import { detect, forEach } from 'mobiledoc-kit/utils/array-utils';
+import AtomNode from 'mobiledoc-kit/models/atom-node';
 import {
   POST_TYPE,
   MARKUP_SECTION_TYPE,
@@ -7,7 +8,8 @@ import {
   LIST_ITEM_TYPE,
   MARKER_TYPE,
   IMAGE_SECTION_TYPE,
-  CARD_TYPE
+  CARD_TYPE,
+  ATOM_TYPE
 } from '../models/types';
 import { startsWith, endsWith } from '../utils/string-utils';
 import { addClassName } from '../utils/dom-utils';
@@ -20,6 +22,7 @@ export const NO_BREAK_SPACE = '\u00A0';
 export const TAB_CHARACTER = '\u2003';
 export const SPACE = ' ';
 export const ZWNJ = '\u200c';
+export const ATOM_CLASS_NAME = '-mobiledoc-kit__atom';
 
 function createElementFromMarkup(doc, markup) {
   let element = doc.createElement(markup.tagName);
@@ -52,11 +55,11 @@ function renderHTMLText(marker) {
   // the cursor.
   // See https://github.com/bustlelabs/mobiledoc-kit/issues/68
   //   and https://github.com/bustlelabs/mobiledoc-kit/issues/75
-  if (endsWithSpace(text) && !marker.next) {
+  if (marker.isMarker && endsWithSpace(text) && !marker.next) {
     text = text.substr(0, text.length - 1) + NO_BREAK_SPACE;
   }
-  if (startsWithSpace(text) &&
-      (!marker.prev || endsWithSpace(marker.prev.value))) {
+  if (marker.isMarker && startsWithSpace(text) &&
+      (!marker.prev || (marker.prev.isMarker && endsWithSpace(marker.prev.value)))) {
     text = NO_BREAK_SPACE + text.substr(1);
   }
   return text;
@@ -98,15 +101,74 @@ function renderCursorPlaceholder() {
   return document.createElement('br');
 }
 
+function renderInlineCursorPlaceholder() {
+  return document.createTextNode(ZWNJ);
+}
+
 function renderCard() {
   let wrapper = document.createElement('div');
   let cardElement = document.createElement('div');
   cardElement.contentEditable = false;
   addClassName(cardElement, CARD_ELEMENT_CLASS_NAME);
-  wrapper.appendChild(document.createTextNode(ZWNJ));
+  wrapper.appendChild(renderInlineCursorPlaceholder());
   wrapper.appendChild(cardElement);
-  wrapper.appendChild(document.createTextNode(ZWNJ));
+  wrapper.appendChild(renderInlineCursorPlaceholder());
   return { wrapper, cardElement };
+}
+
+/**
+ * Wrap the element in all of the opened markups
+ * @return {DOMElement} the wrapped element
+ */
+function wrapElement(element, openedMarkups) {
+  let wrappedElement = element;
+
+  for (let i=openedMarkups.length - 1; i>=0; i--) {
+    let markup = openedMarkups[i];
+    let openedElement = createElementFromMarkup(document, markup);
+    openedElement.appendChild(wrappedElement);
+    wrappedElement = openedElement;
+  }
+
+  return wrappedElement;
+}
+
+// Attach the element to its parent element at the right position based on the
+// previousRenderNode
+function attachElementToParent(element, parentElement, previousRenderNode=null) {
+  if (previousRenderNode) {
+    let previousSibling = previousRenderNode.element;
+    let previousSiblingPenultimate = penultimateParentOf(previousSibling,
+                                                         parentElement);
+    parentElement.insertBefore(element, previousSiblingPenultimate.nextSibling);
+  } else {
+    parentElement.insertBefore(element, parentElement.firstChild);
+  }
+}
+
+function renderAtom(atom, element, previousRenderNode) {
+  let atomElement = document.createElement('span');
+  atomElement.contentEditable = false;
+
+  let wrapper = document.createElement('span');
+  addClassName(wrapper, ATOM_CLASS_NAME);
+  let headTextNode = renderInlineCursorPlaceholder();
+  let tailTextNode = renderInlineCursorPlaceholder();
+
+  wrapper.appendChild(headTextNode);
+  wrapper.appendChild(atomElement);
+  wrapper.appendChild(tailTextNode);
+
+  let wrappedElement = wrapElement(wrapper, atom.openedMarkups);
+  attachElementToParent(wrappedElement, element, previousRenderNode);
+
+  return {
+    markupElement: wrappedElement,
+    wrapper,
+    atomElement,
+    headTextNode,
+    tailTextNode
+  };
 }
 
 function getNextMarkerElement(renderNode) {
@@ -134,33 +196,15 @@ function renderMarker(marker, parentElement, previousRenderNode) {
   let text = renderHTMLText(marker);
 
   let element = document.createTextNode(text);
-  let markupElement = element;
-  let markup;
-
-  const openTypes = marker.openedMarkups;
-  for (let j=openTypes.length-1;j>=0;j--) {
-    markup = openTypes[j];
-    let openedElement = createElementFromMarkup(document, markup);
-    openedElement.appendChild(markupElement);
-    markupElement = openedElement;
-  }
-
-  let referenceElement;
-
-  if (previousRenderNode) {
-    let previousSibling = previousRenderNode.element;
-    let previousSiblingPenultimate = penultimateParentOf(previousSibling, parentElement);
-    referenceElement = previousSiblingPenultimate.nextSibling;
-  } else {
-    referenceElement = parentElement.firstChild;
-  }
-
-  parentElement.insertBefore(markupElement, referenceElement);
+  let markupElement = wrapElement(element, marker.openedMarkups);
+  attachElementToParent(markupElement, parentElement, previousRenderNode);
 
   return { element, markupElement };
 }
 
-function attachRenderNodeElementToDOM(renderNode, originalElement) {
+// Attach the render node's element to the DOM,
+// replacing the originalElement if it exists
+function attachRenderNodeElementToDOM(renderNode, originalElement=null) {
   const element = renderNode.element;
   const hasRendered = !!originalElement;
 
@@ -206,11 +250,27 @@ function validateCards(cards=[]) {
   return cards;
 }
 
+function validateAtoms(atoms=[]) {
+  forEach(atoms, atom => {
+    assert(
+      `Atom "${atom.name}" must define type "dom", has: "${atom.type}"`,
+      atom.type === 'dom'
+    );
+    assert(
+      `Atom "${atom.name}" must define \`render\` method`,
+      !!atom.render
+    );
+  });
+  return atoms;
+}
+
 class Visitor {
-  constructor(editor, cards, unknownCardHandler, options) {
+  constructor(editor, cards, atoms, unknownCardHandler, unknownAtomHandler, options) {
     this.editor = editor;
     this.cards = validateCards(cards);
+    this.atoms = validateAtoms(atoms);
     this.unknownCardHandler = unknownCardHandler;
+    this.unknownAtomHandler = unknownAtomHandler;
     this.options = options;
   }
 
@@ -230,6 +290,24 @@ class Visitor {
       type: 'dom',
       render: this.unknownCardHandler,
       edit:   this.unknownCardHandler
+    };
+  }
+
+  _findAtom(atomName) {
+    let atom = detect(this.atoms, atom => atom.name === atomName);
+    return atom || this._createUnknownAtom(atomName);
+  }
+
+  _createUnknownAtom(atomName) {
+    assert(
+      `Unknown atom "${atomName}" found, but no unknownAtomHandler is defined`,
+      !!this.unknownAtomHandler
+    );
+
+    return {
+      name: atomName,
+      type: 'dom',
+      render: this.unknownAtomHandler
     };
   }
 
@@ -334,6 +412,38 @@ class Visitor {
     const initialMode = section._initialMode;
     cardNode[initialMode]();
   }
+
+  [ATOM_TYPE](renderNode, atomModel) {
+    let parentElement;
+
+    if (renderNode.prev) {
+      parentElement = getNextMarkerElement(renderNode.prev);
+    } else {
+      parentElement = renderNode.parent.element;
+    }
+
+    const { editor, options } = this;
+    const {
+      wrapper,
+      markupElement,
+      atomElement,
+      headTextNode,
+      tailTextNode
+    } = renderAtom(atomModel, parentElement, renderNode.prev);
+    const atom = this._findAtom(atomModel.name);
+
+    const atomNode = new AtomNode(
+      editor, atom, atomModel, atomElement, options
+    );
+
+    atomNode.render();
+
+    renderNode.atomNode = atomNode;
+    renderNode.element = wrapper;
+    renderNode.headTextNode = headTextNode;
+    renderNode.tailTextNode = tailTextNode;
+    renderNode.markupElement = markupElement;
+  }
 }
 
 let destroyHooks = {
@@ -383,6 +493,15 @@ let destroyHooks = {
     }
     removeRenderNodeSectionFromParent(renderNode, section);
     removeRenderNodeElementFromParent(renderNode);
+  },
+
+  [ATOM_TYPE](renderNode, atom) {
+    if (renderNode.atomNode) {
+      renderNode.atomNode.teardown();
+    }
+
+    // an atom is a kind of marker so just call its destroy hook vs copying here
+    destroyHooks[MARKER_TYPE](renderNode, atom);
   }
 };
 
@@ -416,9 +535,9 @@ function lookupNode(renderTree, parentNode, postNode, previousNode) {
 }
 
 export default class Renderer {
-  constructor(editor, cards, unknownCardHandler, options) {
+  constructor(editor, cards, atoms, unknownCardHandler, unknownAtomHandler, options) {
     this.editor = editor;
-    this.visitor = new Visitor(editor, cards, unknownCardHandler, options);
+    this.visitor = new Visitor(editor, cards, atoms, unknownCardHandler, unknownAtomHandler, options);
     this.nodes = [];
     this.hasRendered = false;
   }

--- a/src/js/renderers/mobiledoc/0-3.js
+++ b/src/js/renderers/mobiledoc/0-3.js
@@ -1,0 +1,160 @@
+import {visit, visitArray, compile} from '../../utils/compiler';
+import { objectToSortedKVArray } from '../../utils/array-utils';
+import {
+  POST_TYPE,
+  MARKUP_SECTION_TYPE,
+  LIST_SECTION_TYPE,
+  LIST_ITEM_TYPE,
+  MARKER_TYPE,
+  MARKUP_TYPE,
+  IMAGE_SECTION_TYPE,
+  CARD_TYPE,
+  ATOM_TYPE
+} from '../../models/types';
+
+export const MOBILEDOC_VERSION = '0.3.0';
+export const MOBILEDOC_MARKUP_SECTION_TYPE = 1;
+export const MOBILEDOC_IMAGE_SECTION_TYPE = 2;
+export const MOBILEDOC_LIST_SECTION_TYPE = 3;
+export const MOBILEDOC_CARD_SECTION_TYPE = 10;
+
+export const MOBILEDOC_MARKUP_MARKER_TYPE = 0;
+export const MOBILEDOC_ATOM_MARKER_TYPE = 1;
+
+const visitor = {
+  [POST_TYPE](node, opcodes) {
+    opcodes.push(['openPost']);
+    visitArray(visitor, node.sections, opcodes);
+  },
+  [MARKUP_SECTION_TYPE](node, opcodes) {
+    opcodes.push(['openMarkupSection', node.tagName]);
+    visitArray(visitor, node.markers, opcodes);
+  },
+  [LIST_SECTION_TYPE](node, opcodes) {
+    opcodes.push(['openListSection', node.tagName]);
+    visitArray(visitor, node.items, opcodes);
+  },
+  [LIST_ITEM_TYPE](node, opcodes) {
+    opcodes.push(['openListItem']);
+    visitArray(visitor, node.markers, opcodes);
+  },
+  [IMAGE_SECTION_TYPE](node, opcodes) {
+    opcodes.push(['openImageSection', node.src]);
+  },
+  [CARD_TYPE](node, opcodes) {
+    opcodes.push(['openCardSection', node.name, node.payload]);
+  },
+  [MARKER_TYPE](node, opcodes) {
+    opcodes.push(['openMarker', node.closedMarkups.length, node.value]);
+    visitArray(visitor, node.openedMarkups, opcodes);
+  },
+  [MARKUP_TYPE](node, opcodes) {
+    opcodes.push(['openMarkup', node.tagName, objectToSortedKVArray(node.attributes)]);
+  },
+  [ATOM_TYPE](node, opcodes) {
+    opcodes.push(['openAtom', node.closedMarkups.length, node.name, node.value, node.payload]);
+    visitArray(visitor, node.openedMarkups, opcodes);
+  }
+};
+
+const postOpcodeCompiler = {
+  openMarker(closeCount, value) {
+    this.markupMarkerIds = [];
+    this.markers.push([
+      MOBILEDOC_MARKUP_MARKER_TYPE,
+      this.markupMarkerIds,
+      closeCount,
+      value || ''
+    ]);
+  },
+  openMarkupSection(tagName) {
+    this.markers = [];
+    this.sections.push([MOBILEDOC_MARKUP_SECTION_TYPE, tagName, this.markers]);
+  },
+  openListSection(tagName) {
+    this.items = [];
+    this.sections.push([MOBILEDOC_LIST_SECTION_TYPE, tagName, this.items]);
+  },
+  openListItem() {
+    this.markers = [];
+    this.items.push(this.markers);
+  },
+  openImageSection(url) {
+    this.sections.push([MOBILEDOC_IMAGE_SECTION_TYPE, url]);
+  },
+  openCardSection(name, payload) {
+    const index = this._addCardTypeIndex(name, payload);
+    this.sections.push([MOBILEDOC_CARD_SECTION_TYPE, index]);
+  },
+  openAtom(closeCount, name, value, payload) {
+    const index = this._addAtomTypeIndex(name, value, payload);
+    this.markupMarkerIds = [];
+    this.markers.push([
+      MOBILEDOC_ATOM_MARKER_TYPE,
+      this.markupMarkerIds,
+      closeCount,
+      index
+    ]);
+  },
+  openPost() {
+    this.atomTypes = [];
+    this.cardTypes = [];
+    this.markerTypes = [];
+    this.sections = [];
+    this.result = {
+      version: MOBILEDOC_VERSION,
+      atoms: this.atomTypes,
+      cards: this.cardTypes,
+      markups: this.markerTypes,
+      sections: this.sections
+    };
+  },
+  openMarkup(tagName, attributes) {
+    const index = this._findOrAddMarkerTypeIndex(tagName, attributes);
+    this.markupMarkerIds.push(index);
+  },
+  _addCardTypeIndex(cardName, payload) {
+    let cardType = [cardName, payload];
+    this.cardTypes.push(cardType);
+    return this.cardTypes.length - 1;
+  },
+  _addAtomTypeIndex(atomName, atomValue, payload) {
+    let atomType = [atomName, atomValue, payload];
+    this.atomTypes.push(atomType);
+    return this.atomTypes.length - 1;
+  },
+  _findOrAddMarkerTypeIndex(tagName, attributesArray) {
+    if (!this._markerTypeCache) { this._markerTypeCache = {}; }
+    const key = `${tagName}-${attributesArray.join('-')}`;
+
+    let index = this._markerTypeCache[key];
+    if (index === undefined) {
+      let markerType = [tagName];
+      if (attributesArray.length) { markerType.push(attributesArray); }
+      this.markerTypes.push(markerType);
+
+      index =  this.markerTypes.length - 1;
+      this._markerTypeCache[key] = index;
+    }
+
+    return index;
+  }
+};
+
+/**
+ * Render from post -> mobiledoc
+ */
+export default {
+  /**
+   * @method render
+   * @param {Post}
+   * @return {Mobiledoc}
+   */
+  render(post) {
+    let opcodes = [];
+    visit(visitor, post, opcodes);
+    let compiler = Object.create(postOpcodeCompiler);
+    compile(compiler, opcodes);
+    return compiler.result;
+  }
+};

--- a/src/js/renderers/mobiledoc/index.js
+++ b/src/js/renderers/mobiledoc/index.js
@@ -1,15 +1,18 @@
-import MobiledocRenderer_0_2, { MOBILEDOC_VERSION } from './0-2';
+import MobiledocRenderer_0_2, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2 } from './0-2';
+import MobiledocRenderer_0_3, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from './0-3';
 import assert from 'mobiledoc-kit/utils/assert';
 
-export { MOBILEDOC_VERSION };
+export const MOBILEDOC_VERSION = MOBILEDOC_VERSION_0_3;
 
 export default {
   render(post, version) {
     switch (version) {
-      case MOBILEDOC_VERSION:
+      case MOBILEDOC_VERSION_0_2:
+        return MobiledocRenderer_0_2.render(post);
       case undefined:
       case null:
-        return MobiledocRenderer_0_2.render(post);
+      case MOBILEDOC_VERSION_0_3:
+        return MobiledocRenderer_0_3.render(post);
       default:
         assert(`Unknown version of mobiledoc renderer requested: ${version}`, false);
     }

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -81,7 +81,7 @@ const Cursor = class Cursor {
   }
 
   _findNodeForPosition(position) {
-    const { section } = position;
+    let { section } = position;
     let node, offset;
     if (section.isCardSection) {
       offset = 0;
@@ -94,9 +94,20 @@ const Cursor = class Cursor {
       node = section.renderNode.element;
       offset = 0;
     } else {
-      const {marker, offsetInMarker} = position;
-      node = marker.renderNode.element;
-      offset = offsetInMarker;
+      let {marker, offsetInMarker} = position;
+      if (marker.isAtom) {
+        if (offsetInMarker > 0) {
+          // FIXME -- if there is a next marker, focus on it?
+          offset = 0;
+          node = marker.renderNode.tailTextNode;
+        } else {
+          offset = 0;
+          node = marker.renderNode.headTextNode;
+        }
+      } else {
+        node = marker.renderNode.element;
+        offset = offsetInMarker;
+      }
     }
 
     return {node, offset};

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -1,5 +1,4 @@
 import { forEach } from './array-utils';
-import assert from './assert';
 
 export const NODE_TYPES = {
   ELEMENT: 1,
@@ -13,6 +12,10 @@ function isTextNode(node) {
 
 function isCommentNode(node) {
   return node.nodeType === NODE_TYPES.COMMENT;
+}
+
+function isElementNode(node) {
+  return node.nodeType === NODE_TYPES.ELEMENT;
 }
 
 // perform a pre-order tree traversal of the dom, calling `callbackFn(node)`
@@ -83,28 +86,6 @@ function normalizeTagName(tagName) {
   return tagName.toLowerCase();
 }
 
-/*
- * @param {Node} elementNode not a text node
- * @param {Node} textNode a text node
- * @param {Number} offsetInTextNode optional, the offset relative to the text node
- * @return {Number} The offset relative to all the text nodes in the element node
- */
-function findOffsetInElement(elementNode, textNode, offsetInTextNode=0) {
-  let offset = 0, found = false;
-  walkTextNodes(elementNode, _textNode => {
-    if (found) { return; }
-    if (_textNode === textNode) {
-      found = true;
-      offset += offsetInTextNode;
-    } else {
-      offset += _textNode.textContent.length;
-    }
-  });
-  assert('Unable to find offset of text node in element, it is not a child.',
-         found);
-  return offset;
-}
-
 function parseHTML(html) {
   var div = document.createElement('div');
   div.innerHTML = html;
@@ -121,6 +102,6 @@ export {
   normalizeTagName,
   isTextNode,
   isCommentNode,
-  parseHTML,
-  findOffsetInElement
+  isElementNode,
+  parseHTML
 };

--- a/src/js/utils/lifecycle-callbacks.js
+++ b/src/js/utils/lifecycle-callbacks.js
@@ -6,15 +6,39 @@ export default class LifecycleCallbacksMixin {
     return this._callbackQueues;
   }
   runCallbacks(queueName, args=[]) {
-    this._getQueue(queueName).forEach(cb => cb(...args));
+    this._callbacksForRemoval = [];
+    let queue = this._getQueue(queueName);
+    queue.forEach(cb => cb(...args));
+
+    let toRemove = this._removalQueues[queueName] || [];
+    toRemove.forEach(cb => {
+      if (queue.indexOf(cb) !== -1) {
+        queue.splice(queue.indexOf(cb), 1);
+      }
+    });
+
+    this._removalQueues[queueName] = [];
   }
   addCallback(queueName, callback) {
     this._getQueue(queueName).push(callback);
+  }
+  _scheduleCallbackForRemoval(queueName, callback) {
+    if (!this._removalQueues[queueName]) {
+      this._removalQueues[queueName] = [];
+    }
+    this._removalQueues[queueName].push(callback);
+  }
+  get _removalQueues() {
+    if (!this.__removalQueues) {
+      this.__removalQueues = {};
+    }
+    return this.__removalQueues;
   }
   addCallbackOnce(queueName, callback) {
     let queue = this._getQueue(queueName);
     if (queue.indexOf(callback) === -1) {
       queue.push(callback);
+      this._scheduleCallbackForRemoval(queueName, callback);
     }
   }
   _getQueue(queueName) {

--- a/src/js/utils/markuperable.js
+++ b/src/js/utils/markuperable.js
@@ -1,0 +1,67 @@
+import { normalizeTagName } from '../utils/dom-utils';
+import { detect, commonItemLength, forEach, filter } from '../utils/array-utils';
+
+export default class Markerupable {
+
+  clearMarkups() {
+    this.markups = [];
+  }
+
+  addMarkup(markup) {
+    this.markups.push(markup);
+  }
+
+  removeMarkup(markupOrMarkupCallback) {
+    let callback;
+    if (typeof markupOrMarkupCallback === 'function') {
+      callback = markupOrMarkupCallback;
+    } else {
+      let markup = markupOrMarkupCallback;
+      callback = (_markup) => _markup === markup;
+    }
+
+    forEach(
+      filter(this.markups, callback),
+      m => this._removeMarkup(m)
+    );
+  }
+
+  _removeMarkup(markup) {
+    const index = this.markups.indexOf(markup);
+    if (index !== -1) {
+      this.markups.splice(index, 1);
+    }
+  }
+
+  hasMarkup(tagNameOrMarkup) {
+    return !!this.getMarkup(tagNameOrMarkup);
+  }
+
+  getMarkup(tagNameOrMarkup) {
+    if (typeof tagNameOrMarkup === 'string') {
+      let tagName = normalizeTagName(tagNameOrMarkup);
+      return detect(this.markups, markup => markup.tagName === tagName);
+    } else {
+      let targetMarkup = tagNameOrMarkup;
+      return detect(this.markups, markup => markup === targetMarkup);
+    }
+  }
+
+  get openedMarkups() {
+    let count = 0;
+    if (this.prev) {
+      count = commonItemLength(this.markups, this.prev.markups);
+    }
+
+    return this.markups.slice(count);
+  }
+
+  get closedMarkups() {
+    let count = 0;
+    if (this.next) {
+      count = commonItemLength(this.markups, this.next.markups);
+    }
+
+    return this.markups.slice(count);
+  }
+}

--- a/src/js/utils/paste-utils.js
+++ b/src/js/utils/paste-utils.js
@@ -42,13 +42,14 @@ export function setClipboardCopyData(copyEvent, editor) {
   const mobiledoc = post.cloneRange(range);
 
   let unknownCardHandler = () => {}; // ignore unknown cards
-  let {result: innerHTML } =
-    new HTMLRenderer({unknownCardHandler}).render(mobiledoc);
+  let unknownAtomHandler = () => {}; // ignore unknown atoms
+  let {result: innerHTML} =
+    new HTMLRenderer({unknownCardHandler, unknownAtomHandler}).render(mobiledoc);
 
   const html =
     `<div data-mobiledoc='${JSON.stringify(mobiledoc)}'>${innerHTML}</div>`;
   const {result: plain} =
-    new TextRenderer({unknownCardHandler}).render(mobiledoc);
+    new TextRenderer({unknownCardHandler, unknownAtomHandler}).render(mobiledoc);
 
   clipboardData.setData(MIME_TEXT_PLAIN, plain);
   clipboardData.setData(MIME_TEXT_HTML, html);

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -166,15 +166,14 @@ test('typing tab enters a tab character', (assert) => {
   Helpers.dom.insertText(editor, TAB);
   Helpers.dom.insertText(editor, 'Y');
   window.setTimeout(() => {
-    let editedMobiledoc = editor.serialize();
-    assert.deepEqual(editedMobiledoc.sections, [
-      [],
-      [
-        [1, 'p', [
-          [[], 0, `${TAB}Y`]
-        ]]
-      ]
-    ], 'correctly encoded');
+    let expectedPost = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+      return post([
+        markupSection('p', [
+          marker(`${TAB}Y`)
+        ])
+      ]);
+    });
+    assert.postIsSimilar(editor.post, expectedPost);
     done();
   }, 0);
 });
@@ -219,18 +218,17 @@ test('typing enter splits lines, sets cursor', (assert) => {
   Helpers.dom.moveCursorTo($('#editor p')[0].firstChild, 2);
   Helpers.dom.insertText(editor, ENTER);
   window.setTimeout(() => {
-    let editedMobiledoc = editor.serialize();
-    assert.deepEqual(editedMobiledoc.sections, [
-      [],
-      [
-        [1, 'p', [
-          [[], 0, `hi`]
-        ]],
-        [1, 'p', [
-          [[], 0, `hey`]
-        ]]
-      ]
-    ], 'correctly encoded');
+    let expectedPost = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+      return post([
+        markupSection('p', [
+          marker(`hi`)
+        ]),
+        markupSection('p', [
+          marker(`hey`)
+        ])
+      ]);
+    });
+    assert.postIsSimilar(editor.post, expectedPost, 'correctly encoded');
     let expectedRange = new Range(new Position(editor.post.sections.tail, 0));
     assert.ok(expectedRange.isEqual(editor.range), 'range is at start of new section');
     done();

--- a/tests/acceptance/cursor-position-test.js
+++ b/tests/acceptance/cursor-position-test.js
@@ -10,6 +10,14 @@ const cards = [{
   edit() {}
 }];
 
+const atoms = [{
+  name: 'my-atom',
+  type: 'dom',
+  render() {
+    return document.createTextNode('my-atom');
+  }
+}];
+
 let editor, editorElement;
 
 module('Acceptance: Cursor Position', {
@@ -215,4 +223,118 @@ test('selecting the entire editor element reports a selection range of the entir
   assert.ok(offsets.tail.section === editor.post.sections.tail,
             'tail section correct');
   assert.equal(offsets.tail.offset, 4, 'tail offset equals section length');
+});
+
+test('when at the head of an atom', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker, atom}) => {
+    return post([
+      markupSection('p', [
+        marker('aa'),
+        atom('my-atom'),
+        marker('cc')
+      ])
+    ]);
+  // TODO just make 0.3.0 default
+  }, '0.3.0');
+  editor = new Editor({mobiledoc, atoms});
+  editor.render(editorElement);
+
+  let atomWrapper = editor.post.sections.head.markers.objectAt(1).renderNode.element;
+
+  // Before zwnj
+  //
+  Helpers.dom.moveCursorTo(atomWrapper.firstChild, 0);
+  let range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 2,
+               'Cursor is positioned at offset 2');
+
+  // After zwnj
+  //
+  Helpers.dom.moveCursorTo(atomWrapper.firstChild, 1);
+  range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 2,
+               'Cursor is positioned at offset 2');
+
+  // On wrapper
+  //
+  Helpers.dom.moveCursorTo(atomWrapper, 1);
+  range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 2,
+               'Cursor is positioned at offset 3');
+
+  // After wrapper
+  //
+  Helpers.dom.moveCursorTo(atomWrapper.previousSibling, 2);
+  range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 2,
+               'Cursor is positioned at offset 2');
+});
+
+test('when at the tail of an atom', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker, atom}) => {
+    return post([
+      markupSection('p', [
+        marker('aa'),
+        atom('my-atom'),
+        marker('cc')
+      ])
+    ]);
+  // TODO just make 0.3.0 default
+  }, '0.3.0');
+  editor = new Editor({mobiledoc, atoms});
+  editor.render(editorElement);
+
+  let atomWrapper = editor.post.sections.head.markers.objectAt(1).renderNode.element;
+
+  // Before zwnj
+  //
+  Helpers.dom.moveCursorTo(atomWrapper.lastChild, 0);
+  let range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 3,
+               'Cursor is positioned at offset 3');
+
+  // After zwnj
+  //
+  Helpers.dom.moveCursorTo(atomWrapper.lastChild, 1);
+  range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 3,
+               'Cursor is positioned at offset 3');
+
+  // On wrapper
+  //
+  Helpers.dom.moveCursorTo(atomWrapper, 2);
+  range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 3,
+               'Cursor is positioned at offset 3');
+
+  // After wrapper
+  //
+  Helpers.dom.moveCursorTo(atomWrapper.nextSibling, 0);
+  range = editor.range;
+
+  assert.ok(range.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(range.head.offset, 3,
+               'Cursor is positioned at offset 3');
 });

--- a/tests/acceptance/editor-atoms-test.js
+++ b/tests/acceptance/editor-atoms-test.js
@@ -1,0 +1,329 @@
+import { Editor } from 'mobiledoc-kit';
+import Helpers from '../test-helpers';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
+import Range from 'mobiledoc-kit/utils/cursor/range';
+
+const { test, module } = Helpers;
+
+const simpleAtom = {
+  name: 'simple-atom',
+  type: 'dom',
+  render({value}) {
+    let element = document.createElement('span');
+    element.setAttribute('id', 'simple-atom');
+    element.appendChild(document.createTextNode(value));
+    return element;
+  }
+};
+
+let editor, editorElement;
+const mobiledocWithAtom = {
+  version: MOBILEDOC_VERSION,
+  atoms: [
+    ['simple-atom', 'Bob']
+  ],
+  cards: [],
+  markups: [],
+  sections: [
+    [1, "P", [
+      [0, [], 0, "text before atom"],
+      [1, [], 0, 0],
+      [0, [], 0, "text after atom"]
+    ]]
+  ]
+};
+let editorOptions = { atoms: [simpleAtom] };
+
+module('Acceptance: Atoms', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+
+  afterEach() {
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
+  }
+});
+
+test('keystroke of character before starting atom inserts character', (assert) => {
+  let done = assert.async();
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, atom, markupSection, marker}) => {
+    expected = post([markupSection('p', [marker('A'), atom('simple-atom', 'first')])]);
+    return post([markupSection('p', [atom('simple-atom', 'first')])]);
+  }, editorOptions);
+
+  editor.selectRange(new Range(editor.post.headPosition()));
+  Helpers.dom.insertText(editor, 'A');
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.renderTreeIsEqual(editor._renderTree, expected);
+    done();
+  });
+});
+
+test('keystroke of character before mid-text atom inserts character', (assert) => {
+  let done = assert.async();
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, atom, markupSection, marker}) => {
+    expected = post([markupSection('p', [marker('ABC'), atom('simple-atom', 'first')])]);
+    return post([markupSection('p', [marker('AB'), atom('simple-atom', 'first')])]);
+  }, editorOptions);
+
+  editor.selectRange(Range.create(editor.post.sections.head, 'AB'.length));
+  Helpers.dom.insertText(editor, 'C');
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.renderTreeIsEqual(editor._renderTree, expected);
+    done();
+  });
+});
+
+test('keystroke of character after mid-text atom inserts character', (assert) => {
+  let done = assert.async();
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, atom, markupSection, marker}) => {
+    expected = post([markupSection('p', [atom('simple-atom', 'first'), marker('ABC')])]);
+    return post([markupSection('p', [atom('simple-atom', 'first'), marker('BC')])]);
+  }, editorOptions);
+
+  editor.selectRange(Range.create(editor.post.sections.head, 1));
+  Helpers.dom.insertText(editor, 'A');
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.renderTreeIsEqual(editor._renderTree, expected);
+    done();
+  });
+});
+
+test('keystroke of character after end-text atom inserts character', (assert) => {
+  let done = assert.async();
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, atom, markupSection, marker}) => {
+    expected = post([markupSection('p', [atom('simple-atom', 'first'), marker('A')])]);
+    return post([markupSection('p', [atom('simple-atom', 'first')])]);
+  }, editorOptions);
+
+  editor.selectRange(Range.create(editor.post.sections.head, 1));
+  Helpers.dom.insertText(editor, 'A');
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.renderTreeIsEqual(editor._renderTree, expected);
+    done();
+  });
+});
+
+test('keystroke of delete removes character after atom', (assert) => {
+  editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
+  editor.render(editorElement);
+
+  let pNode = $('#editor p')[0];
+  Helpers.dom.moveCursorTo(pNode.lastChild, 1);
+  Helpers.dom.triggerDelete(editor);
+
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, markupSection, atom, marker}) => {
+      return post([markupSection('p', [
+        marker('text before atom'),
+        atom('simple-atom', 'Bob'),
+        marker('ext after atom')
+      ])]);
+    }));
+});
+
+test('keystroke of delete removes atom', (assert) => {
+  editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
+  editor.render(editorElement);
+
+  let pNode = $('#editor p')[0];
+  Helpers.dom.moveCursorTo(pNode.lastChild, 0);
+  Helpers.dom.triggerDelete(editor);
+
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, markupSection, atom, marker}) => {
+      return post([markupSection('p', [
+        marker('text before atomtext after atom')
+      ])]);
+    }));
+});
+
+test('keystroke of forward delete removes atom', (assert) => {
+  editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
+  editor.render(editorElement);
+
+  let pNode = $('#editor p')[0];
+  Helpers.dom.moveCursorTo(pNode.firstChild, 16);
+  Helpers.dom.triggerForwardDelete(editor);
+
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, markupSection, atom, marker}) => {
+      return post([markupSection('p', [
+        marker('text before atomtext after atom')
+      ])]);
+    }));
+});
+
+test('keystroke of enter in section with atom creates new section', (assert) => {
+  editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
+  editor.render(editorElement);
+
+  let pNode = $('#editor p')[0];
+  Helpers.dom.moveCursorTo(pNode.lastChild, 1);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, markupSection, atom, marker}) => {
+      return post([
+        markupSection('p', [
+          marker('text before atom'),
+          atom('simple-atom', 'Bob'),
+          marker('t')
+        ]),
+        markupSection('p', [
+          marker('ext after atom')
+        ])
+      ]);
+    }));
+});
+
+test('keystroke of enter after atom and before marker creates new section', (assert) => {
+  editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
+  editor.render(editorElement);
+
+  let pNode = $('#editor p')[0];
+  Helpers.dom.moveCursorTo(pNode.lastChild, 0);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, markupSection, atom, marker}) => {
+      return post([
+        markupSection('p', [
+          marker('text before atom'),
+          atom('simple-atom', 'Bob')
+        ]),
+        markupSection('p', [
+          marker('text after atom')
+        ])
+      ]);
+    }));
+});
+
+test('keystroke of enter before atom and after marker creates new section', (assert) => {
+  editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
+  editor.render(editorElement);
+
+  let pNode = $('#editor p')[0];
+  Helpers.dom.moveCursorTo(pNode.firstChild, 16);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, markupSection, atom, marker}) => {
+      return post([
+        markupSection('p', [
+          marker('text before atom')
+        ]),
+        markupSection('p', [
+          atom('simple-atom', 'Bob'),
+          marker('text after atom')
+        ])
+      ]);
+    }));
+});
+
+test('marking atom with markup adds markup', (assert) => {
+  editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
+  editor.render(editorElement);
+
+  let pNode = $('#editor p')[0];
+  Helpers.dom.selectRange(pNode.firstChild, 16, pNode.lastChild, 0);
+  editor.run(postEditor => {
+    let markup = editor.builder.createMarkup('strong');
+    postEditor.addMarkupToRange(editor.range, markup);
+  });
+
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, markupSection, atom, marker, markup}) => {
+      return post([
+        markupSection('p', [
+          marker('text before atom'),
+          atom('simple-atom', 'Bob', {}, [markup('strong')]),
+          marker('text after atom')
+        ])
+      ]);
+    }));
+});
+
+test('typing between two atoms inserts character', (assert) => {
+  let done = assert.async();
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(
+    editorElement, ({post, markupSection, atom, marker}) => {
+    expected = post([markupSection('p', [
+      atom('simple-atom', 'first'),
+      marker('A'),
+      atom('simple-atom', 'last')
+    ])]);
+    return post([markupSection('p', [
+      atom('simple-atom', 'first'),
+      atom('simple-atom', 'last')
+    ])]);
+  }, editorOptions);
+
+  editor.selectRange(Range.create(editor.post.sections.head, 1));
+
+  Helpers.dom.insertText(editor, 'A');
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expected);
+    assert.renderTreeIsEqual(editor._renderTree, expected);
+    done();
+  });
+});
+
+test('delete selected text including atom deletes atom', (assert) => {
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker, atom}) => {
+    expected = post([markupSection('p', [marker('abc')])]);
+    return post([markupSection('p', [
+      marker('ab'), atom('simple-atom', 'deleteme'), marker('c')
+    ])]);
+  }, editorOptions);
+
+  let section = editor.post.sections.head;
+  editor.selectRange(Range.create(section, 'ab'.length,
+                                  section, 'ab'.length + 1));
+
+  Helpers.dom.triggerDelete(editor);
+
+  assert.postIsSimilar(editor.post, expected);
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+});
+
+test('delete selected text that ends between atoms deletes first atom', (assert) => {
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker, atom}) => {
+    expected = post([markupSection('p', [
+      marker('abd'),
+      atom('simple-atom', 'keepme')
+    ])]);
+    return post([markupSection('p', [
+      marker('ab'), atom('simple-atom', 'deleteme'),
+      marker('cd'), atom('simple-atom', 'keepme')
+    ])]);
+  }, editorOptions);
+
+  let section = editor.post.sections.head;
+  editor.selectRange(Range.create(section, 'ab'.length,
+                                  section, 'ab'.length + 1 + 'c'.length));
+
+  Helpers.dom.triggerDelete(editor);
+
+  assert.postIsSimilar(editor.post, expected);
+  assert.renderTreeIsEqual(editor._renderTree, expected);
+});

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -327,30 +327,24 @@ test('pasting when on the end of a card is blocked', (assert) => {
   editor.selectRange(new Range(editor.post.sections.head.headPosition()));
   Helpers.dom.triggerPasteEvent(editor);
 
-  let updatedMobiledoc = editor.serialize();
-  assert.deepEqual(updatedMobiledoc.sections, [
-    [],
-    [
-      [10, 'my-card', {}],
-      [1, 'p', [
-        [[], 0, 'abc']
-      ]]
-    ]
-  ], 'no paste has occurred');
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, marker}) => {
+      return post([
+        cardSection('my-card'),
+        markupSection('p', [marker('abc')])
+      ]);
+    }), 'no paste has occurred');
 
   editor.selectRange(new Range(editor.post.sections.head.tailPosition()));
   Helpers.dom.triggerPasteEvent(editor);
 
-  updatedMobiledoc = editor.serialize();
-  assert.deepEqual(updatedMobiledoc.sections, [
-    [],
-    [
-      [10, 'my-card', {}],
-      [1, 'p', [
-        [[], 0, 'abc']
-      ]]
-    ]
-  ], 'no paste has occurred');
+  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+    ({post, cardSection, markupSection, marker}) => {
+      return post([
+        cardSection('my-card'),
+        markupSection('p', [marker('abc')])
+      ]);
+    }), 'no paste has occurred');
 });
 
 // see https://github.com/bustlelabs/mobiledoc-kit/issues/249

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -359,4 +359,3 @@ test('returning false from key command still runs built-in functionality', (asse
 
   assert.equal($('#editor p').length, 2, 'has added a new paragraph');
 });
-

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -1,6 +1,6 @@
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
-import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import { NO_BREAK_SPACE } from 'mobiledoc-kit/renderers/editor-dom';
 
 const { test, module } = Helpers;
@@ -276,7 +276,7 @@ test('keystroke of delete removes emoji character', (assert) => {
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   let textNode = editorElement.firstChild. // section
-                               firstChild; // marker 
+                               firstChild; // marker
   assert.equal(textNode.textContent, monkey, 'precond - correct text');
 
   Helpers.dom.moveCursorTo(textNode, monkey.length);
@@ -293,7 +293,7 @@ test('keystroke of forward delete removes emoji character', (assert) => {
   editor = new Editor({mobiledoc});
   editor.render(editorElement);
   let textNode = editorElement.firstChild. // section
-                               firstChild; // marker 
+                               firstChild; // marker
   assert.equal(textNode.textContent, monkey, 'precond - correct text');
 
   Helpers.dom.moveCursorTo(textNode, 'monkey'.length);

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -1,6 +1,6 @@
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
-import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 
 const { test, module } = Helpers;
 

--- a/tests/helpers/assertions.js
+++ b/tests/helpers/assertions.js
@@ -10,8 +10,26 @@ import {
   POST_TYPE,
   LIST_ITEM_TYPE,
   CARD_TYPE,
-  IMAGE_SECTION_TYPE
+  IMAGE_SECTION_TYPE,
+  ATOM_TYPE
 } from 'mobiledoc-kit/models/types';
+
+/*jshint latedef: false */
+function compareMarkers(actual, expected, assert, path, deepCompare) {
+  if (actual.value !== expected.value) {
+    assert.equal(actual.value, expected.value, `wrong value at ${path}`);
+  }
+  if (actual.markups.length !== expected.markups.length) {
+    assert.equal(actual.markups.length, expected.markups.length,
+                 `wrong markups at ${path}`);
+  }
+  if (deepCompare) {
+    actual.markups.forEach((markup, index) => {
+      comparePostNode(markup, expected.markups[index],
+                      assert, `${path}:${index}`, deepCompare);
+    });
+  }
+}
 
 function comparePostNode(actual, expected, assert, path='root', deepCompare=false) {
   if (!actual || !expected) {
@@ -36,20 +54,14 @@ function comparePostNode(actual, expected, assert, path='root', deepCompare=fals
         });
       }
       break;
+    case ATOM_TYPE:
+      if (actual.name !== expected.name) {
+        assert.equal(actual.name, expected.name, `wrong atom name at ${path}`);
+      }
+      compareMarkers(actual, expected, assert, path, deepCompare);
+      break;
     case MARKER_TYPE:
-      if (actual.value !== expected.value) {
-        assert.equal(actual.value, expected.value, `wrong value at ${path}`);
-      }
-      if (actual.markups.length !== expected.markups.length) {
-        assert.equal(actual.markups.length, expected.markups.length,
-                     `wrong markups at ${path}`);
-      }
-      if (deepCompare) {
-        actual.markups.forEach((markup, index) => {
-          comparePostNode(markup, expected.markups[index],
-                          assert, `${path}:${index}`, deepCompare);
-        });
-      }
+      compareMarkers(actual, expected, assert, path, deepCompare);
       break;
     case MARKUP_SECTION_TYPE:
     case LIST_ITEM_TYPE:

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -315,6 +315,7 @@ function fromHTML(html) {
 
 const DOMHelper = {
   moveCursorTo,
+  selectRange,
   selectText,
   clearSelection,
   triggerEvent,

--- a/tests/helpers/mobiledoc.js
+++ b/tests/helpers/mobiledoc.js
@@ -1,6 +1,7 @@
 import PostAbstractHelpers from './post-abstract';
 import mobiledocRenderers from 'mobiledoc-kit/renderers/mobiledoc';
-import MobiledocRenderer_0_2, { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
+import MobiledocRenderer_0_2, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_2 } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
+import MobiledocRenderer_0_3, { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
 import Editor from 'mobiledoc-kit/editor/editor';
 import { mergeWithOptions } from 'mobiledoc-kit/utils/merge';
 
@@ -17,8 +18,10 @@ import { mergeWithOptions } from 'mobiledoc-kit/utils/merge';
 function build(treeFn, version) {
   let post = PostAbstractHelpers.build(treeFn);
   switch (version) {
-    case MOBILEDOC_VERSION:
+    case MOBILEDOC_VERSION_0_2:
       return MobiledocRenderer_0_2.render(post);
+    case MOBILEDOC_VERSION_0_3:
+      return MobiledocRenderer_0_3.render(post);
     case undefined:
     case null:
       return mobiledocRenderers.render(post);

--- a/tests/helpers/post-abstract.js
+++ b/tests/helpers/post-abstract.js
@@ -20,7 +20,8 @@ function build(treeFn) {
     marker        : (...args) => builder.createMarker(...args),
     listSection   : (...args) => builder.createListSection(...args),
     listItem      : (...args) => builder.createListItem(...args),
-    cardSection   : (...args) => builder.createCardSection(...args)
+    cardSection   : (...args) => builder.createCardSection(...args),
+    atom          : (...args) => builder.createAtom(...args)
   };
 
   return treeFn(simpleBuilder);

--- a/tests/unit/editor/atom-lifecycle-test.js
+++ b/tests/unit/editor/atom-lifecycle-test.js
@@ -1,0 +1,236 @@
+import Helpers from '../../test-helpers';
+import { Editor } from 'mobiledoc-kit';
+let editorElement, editor;
+
+import { MOBILEDOC_VERSION as MOBILEDOC_VERSION_0_3 } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
+
+const { module, test } = Helpers;
+
+module('Unit: Editor: Atom Lifecycle', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+  afterEach() {
+    if (editor) {
+      try {
+        editor.destroy();
+      } catch(e) {}
+      editor = null;
+    }
+  }
+});
+
+
+function makeEl(id) {
+  let el = document.createElement('span');
+  el.id = id;
+  return el;
+}
+
+// Default version is 0.2 for the moment
+function build(fn) {
+  return Helpers.mobiledoc.build(fn, MOBILEDOC_VERSION_0_3);
+}
+
+function assertRenderArguments(assert, args, expected) {
+  let {env, options, payload} = args;
+
+  assert.deepEqual(payload, expected.payload, 'correct payload');
+  assert.deepEqual(options, expected.options, 'correct options');
+
+  // basic env
+  let {name, onTeardown} = env;
+  assert.equal(name, expected.name, 'correct name');
+  assert.ok(!!onTeardown, 'has onTeardown');
+}
+
+test('rendering a mobiledoc with atom calls atom#render', (assert) => {
+  const atomPayload = { foo: 'bar' };
+  const atomValue = "@bob";
+  const cardOptions = { boo: 'baz' };
+  const atomName = 'test-atom';
+
+  let renderArg;
+
+  const atom = {
+    name: atomName,
+    type: 'dom',
+    render(_renderArg) {
+      renderArg = _renderArg;
+    }
+  };
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, atomValue, atomPayload)])])
+  );
+
+  editor = new Editor({mobiledoc, atoms: [atom], cardOptions});
+  editor.render(editorElement);
+
+  let expected = {
+    name: atomName,
+    payload: atomPayload,
+    options: cardOptions
+  };
+  assertRenderArguments(assert, renderArg, expected);
+});
+
+test('rendering a mobiledoc with atom appends result of atom#render', (assert) => {
+  const atomName = 'test-atom';
+
+  const atom = {
+    name: atomName,
+    type: 'dom',
+    render() {
+      return makeEl('the-atom');
+    }
+  };
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+  editor = new Editor({mobiledoc, atoms: [atom]});
+  assert.hasNoElement('#editor #the-atom', 'precond - atom not rendered');
+  editor.render(editorElement);
+  assert.hasElement('#editor #the-atom');
+});
+
+test('returning wrong type from render throws', (assert) => {
+  const atomName = 'test-atom';
+
+  const atom = {
+    name: atomName,
+    type: 'dom',
+    render() {
+      return 'string';
+    }
+  };
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+  editor = new Editor({mobiledoc, atoms: [atom]});
+
+  assert.throws(() => {
+    editor.render(editorElement);
+  }, new RegExp(`Atom "${atomName}" must return a DOM node`));
+});
+
+test('returning undefined from render is ok', (assert) => {
+  const atomName = 'test-atom';
+
+  const atom = {
+    name: atomName,
+    type: 'dom',
+    render() {}
+  };
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+  editor = new Editor({mobiledoc, atoms: [atom]});
+  editor.render(editorElement);
+  assert.ok(true, 'no errors are thrown');
+});
+
+test('rendering atom with wrong type throws', (assert) => {
+  const atomName = 'test-atom';
+  const atom = {
+    name: atomName,
+    type: 'other',
+    render() {}
+  };
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+
+  assert.throws(() => {
+    editor = new Editor({mobiledoc, atoms: [atom]});
+    editor.render(editorElement);
+  }, new RegExp(`Atom "${atomName}.* must define type`));
+});
+
+test('rendering atom without render method throws', (assert) => {
+  const atomName = 'test-atom';
+  const atom = {
+    name: atomName,
+    type: 'dom'
+  };
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+
+  assert.throws(() => {
+    editor = new Editor({mobiledoc, atoms: [atom]});
+    editor.render(editorElement);
+  }, new RegExp(`Atom "${atomName}.* must define.*render`));
+});
+
+test('rendering unknown atom calls #unknownAtomHandler', (assert) => {
+  const payload = { foo: 'bar' };
+  const cardOptions = { boo: 'baz' };
+  const atomName = 'test-atom';
+  const atomValue = '@bob';
+
+  let unknownArg;
+  const unknownAtomHandler = (_unknownArg) => {
+    unknownArg = _unknownArg;
+  };
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, atomValue, payload)])])
+  );
+
+  editor = new Editor({mobiledoc, unknownAtomHandler, cardOptions});
+  editor.render(editorElement);
+
+  let expected = {
+    name: atomName,
+    value: atomValue,
+    options: cardOptions,
+    payload
+  };
+  assertRenderArguments(assert, unknownArg, expected);
+});
+
+test('rendering unknown atom without unknownAtomHandler throws', (assert) => {
+  const atomName = 'test-atom';
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+
+  editor = new Editor({mobiledoc, unknownAtomHandler: undefined});
+
+  assert.throws(() => {
+    editor.render(editorElement);
+  }, new RegExp(`Unknown atom "${atomName}".*no unknownAtomHandler`));
+});
+
+
+
+test('onTeardown hook is called when editor is destroyed', (assert) => {
+  const atomName = 'test-atom';
+
+  let teardown;
+
+  const atom = {
+    name: atomName,
+    type: 'dom',
+    render({env}) {
+      env.onTeardown(() => teardown = true);
+    }
+  };
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+  editor = new Editor({mobiledoc, atoms: [atom]});
+  editor.render(editorElement);
+
+  assert.ok(!teardown, 'nothing torn down yet');
+
+  editor.destroy();
+
+  assert.ok(teardown, 'onTeardown hook called');
+});

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -1,7 +1,7 @@
 import Editor from 'mobiledoc-kit/editor/editor';
 import { EDITOR_ELEMENT_CLASS_NAME } from 'mobiledoc-kit/editor/editor';
 import { normalizeTagName } from 'mobiledoc-kit/utils/dom-utils';
-import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import Range from 'mobiledoc-kit/utils/cursor/range';
 import Helpers from '../../test-helpers';
 
@@ -139,17 +139,9 @@ test('editor fires update event', (assert) => {
 });
 
 test('editor parses and renders mobiledoc format', (assert) => {
-  const mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [],
-      [
-        [1, normalizeTagName('p'), [
-          [[], 0, 'hello world']
-        ]]
-      ]
-    ]
-  };
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('hello world')])]);
+  });
   editorElement.innerHTML = '<p>something here</p>';
   editor = new Editor({mobiledoc});
   editor.render(editorElement);

--- a/tests/unit/models/atom-test.js
+++ b/tests/unit/models/atom-test.js
@@ -1,0 +1,25 @@
+const {module, test} = QUnit;
+
+import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
+
+let builder;
+module('Unit: Atom', {
+  beforeEach() {
+    builder = new PostNodeBuilder();
+  },
+  afterEach() {
+    builder = null;
+  }
+});
+
+test('can create an atom with value and payload', (assert) => {
+  let payload = {};
+  let value = 'atom-value';
+  let name = 'atom-name';
+  let atom = builder.createAtom(name, value, payload);
+  assert.ok(!!atom, 'creates atom');
+  assert.ok(atom.name === name, 'has name');
+  assert.ok(atom.value === value, 'has value');
+  assert.ok(atom.payload === payload, 'has payload');
+  assert.ok(atom.length === 1, 'has length of 1');
+});

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -48,19 +48,6 @@ test('a marker can have the same complex markup tagName applied twice, even with
                'first markup is applied');
 });
 
-test('a marker can be joined to another', (assert) => {
-  const m1 = builder.createMarker('hi');
-  m1.addMarkup(builder.createMarkup('b'));
-  const m2 = builder.createMarker(' there!');
-  m2.addMarkup(builder.createMarkup('i'));
-
-  const m3 = m1.join(m2);
-  assert.equal(m3.builder, builder, 'joined marker also has builder');
-  assert.equal(m3.value, 'hi there!');
-  assert.ok(m3.hasMarkup('b'));
-  assert.ok(m3.hasMarkup('i'));
-});
-
 test('#split splits a marker in 3 with blank markers when no endOffset is passed', (assert) => {
   const m1 = builder.createMarker('hi there!');
   m1.addMarkup(builder.createMarkup('b'));
@@ -72,7 +59,7 @@ test('#split splits a marker in 3 with blank markers when no endOffset is passed
 
   assert.equal(beforeMarker.value, 'hi th');
   assert.equal(afterMarkers[0].value, 'ere!');
-  assert.ok(afterMarkers[1].isEmpty, 'final split marker is empty');
+  assert.ok(afterMarkers[1].isBlank, 'final split marker is empty');
 });
 
 test('#split splits a marker in 3 when endOffset is passed', (assert) => {
@@ -94,9 +81,9 @@ test('#split creates an initial empty marker if the offset is 0', (assert) => {
   const m = builder.createMarker('hi there!');
   const [beforeMarker, ...afterMarkers] = m.split(0);
   assert.equal(afterMarkers.length, 2, '2 after markers');
-  assert.ok(beforeMarker.isEmpty, 'beforeMarker is empty');
+  assert.ok(beforeMarker.isBlank, 'beforeMarker is empty');
   assert.equal(afterMarkers[0].value, 'hi there!');
-  assert.ok(afterMarkers[1].isEmpty, 'final afterMarker is empty');
+  assert.ok(afterMarkers[1].isBlank, 'final afterMarker is empty');
 });
 
 test('#clone a marker', (assert) => {

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -1,7 +1,7 @@
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
-import TestHelpers from '../../test-helpers';
+import Helpers from '../../test-helpers';
 
-const {module, test} = TestHelpers;
+const {module, test} = Helpers;
 
 let builder;
 module('Unit: Markup Section', {
@@ -257,4 +257,44 @@ test('splitMarkerAtOffset splits a marker deep in the middle', (assert) => {
 test('a section has property `isSection`', (assert) => {
   let section = builder.createMarkupSection();
   assert.ok(section.isSection, 'section.isSection');
+});
+
+test('#length is correct', (assert) => {
+  let expectations;
+  Helpers.postAbstract.build(({markupSection, marker, atom}) => {
+    expectations = [{
+      name: 'blank section',
+      length: 0,
+      section: markupSection()
+    }, {
+      name: 'section with empty marker',
+      length: 0,
+      section: markupSection('p', [marker('')])
+    }, {
+      name: 'section with single marker',
+      length: 'abc'.length,
+      section: markupSection('p', [marker('abc')])
+    }, {
+      name: 'section with multiple markers',
+      length: 'abc'.length + 'defg'.length,
+      section: markupSection('p', [marker('abc'),marker('defg')])
+    }, {
+      name: 'section with atom',
+      length: 1,
+      section: markupSection('p', [atom('mention', 'bob')])
+    }, {
+      name: 'section with multiple atoms',
+      length: 2,
+      section: markupSection('p', [atom('mention', 'bob'), atom('mention','other')])
+    }, {
+      name: 'section with atom and markers',
+      length: 'abc'.length + 1,
+      section: markupSection('p', [marker('abc'), atom('mention', 'bob')])
+    }];
+  });
+
+  assert.expect(expectations.length);
+  expectations.forEach(({name, length, section}) => {
+    assert.equal(section.length, length, `${name} has correct length`);
+  });
 });

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -1,5 +1,5 @@
 import mobiledocParsers from 'mobiledoc-kit/parsers/mobiledoc';
-import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 import Helpers from '../../test-helpers';
 

--- a/tests/unit/parsers/mobiledoc/0-3-test.js
+++ b/tests/unit/parsers/mobiledoc/0-3-test.js
@@ -1,0 +1,239 @@
+import MobiledocParser from 'mobiledoc-kit/parsers/mobiledoc/0-3';
+import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
+import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
+
+const DATA_URL = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
+const { module, test } = window.QUnit;
+
+let parser, builder, post;
+
+module('Unit: Parsers: Mobiledoc 0.3', {
+  beforeEach() {
+    builder = new PostNodeBuilder();
+    parser = new MobiledocParser(builder);
+    post = builder.createPost();
+  },
+  afterEach() {
+    parser = null;
+    builder = null;
+    post = null;
+  }
+});
+
+test('#parse empty doc returns an empty post', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: []
+  };
+
+  const parsed = parser.parse(mobiledoc);
+  assert.equal(parsed.sections.length, 0, '0 sections');
+});
+
+test('#parse empty markup section returns an empty post', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [1, 'p', []]
+    ]
+  };
+
+  const section = builder.createMarkupSection('p');
+  post.sections.append(section);
+  assert.deepEqual(parser.parse(mobiledoc), post);
+});
+
+test('#parse doc without marker types', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [
+        1,'P', [[0, [], 0, 'hello world']]
+      ]
+    ]
+  };
+  const parsed = parser.parse(mobiledoc);
+
+  let section = builder.createMarkupSection('P', [], false);
+  let marker  = builder.createMarker('hello world');
+  section.markers.append(marker);
+  post.sections.append(section);
+
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});
+
+test('#parse doc with blank marker', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [
+        1,'P', [[0, [], 0, '']]
+      ]
+    ]
+  };
+  const parsed = parser.parse(mobiledoc);
+
+  let section = builder.createMarkupSection('P', [], false);
+  post.sections.append(section);
+
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});
+
+test('#parse doc with marker type', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [
+      ['B'],
+      ['A', ['href', 'google.com']]
+    ],
+    sections: [
+      [
+        1,'P', [
+          [0, [1], 0, 'hello'],     // a tag open
+          [0, [0], 1, 'brave new'], // b tag open/close
+          [0, [], 1, 'world']       // a tag close
+        ]
+      ]
+    ]
+  };
+  const parsed = parser.parse(mobiledoc);
+
+  let section = builder.createMarkupSection('P', [], false);
+  let aMarkerType = builder.createMarkup('A', {href:'google.com'});
+  let bMarkerType = builder.createMarkup('B');
+
+  let markers  = [
+    builder.createMarker('hello', [aMarkerType]),
+    builder.createMarker('brave new', [aMarkerType, bMarkerType]),
+    builder.createMarker('world', [aMarkerType])
+  ];
+  markers.forEach(marker => section.markers.append(marker));
+  post.sections.append(section);
+
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});
+
+test('#parse doc with image section', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [2, DATA_URL]
+    ]
+  };
+
+  const parsed = parser.parse(mobiledoc);
+
+  let section = builder.createImageSection(DATA_URL);
+  post.sections.append(section);
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});
+
+test('#parse doc with custom card type', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [
+      ['custom-card', {}]
+    ],
+    markups: [],
+    sections: [
+      [10, 0]
+    ]
+  };
+
+  const parsed = parser.parse(mobiledoc);
+
+  let section = builder.createCardSection('custom-card');
+  post.sections.append(section);
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});
+
+test('#parse doc with custom atom type', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [
+      ['mention', '@bob', { id: 42 }]
+    ],
+    cards: [],
+    markups: [],
+    sections: [
+      [
+        1,'P', [
+          [1, [], 0, 0]
+        ]
+      ]
+    ]
+  };
+
+  const parsed = parser.parse(mobiledoc);
+
+  let section = builder.createMarkupSection('P', [], false);
+  let atom = builder.createAtom('mention', '@bob', { id: 42 });
+  section.markers.append(atom);
+  post.sections.append(section);
+
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});
+
+test('#parse a mobile doc with list-section and list-item', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [3, 'ul', [
+        [[0, [], 0, "first item"]],
+        [[0, [], 0, "second item"]]
+      ]]
+    ]
+  };
+
+  const parsed = parser.parse(mobiledoc);
+
+  const items = [
+    builder.createListItem([builder.createMarker('first item')]),
+    builder.createListItem([builder.createMarker('second item')])
+  ];
+  const section = builder.createListSection('ul', items);
+  post.sections.append(section);
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});

--- a/tests/unit/renderers/mobiledoc-test.js
+++ b/tests/unit/renderers/mobiledoc-test.js
@@ -14,6 +14,9 @@ test('renders a blank post', (assert) => {
   let mobiledoc = render(post);
   assert.deepEqual(mobiledoc, {
     version: MOBILEDOC_VERSION,
-    sections: [[], []]
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: []
   });
 });

--- a/tests/unit/renderers/mobiledoc/0-3-test.js
+++ b/tests/unit/renderers/mobiledoc/0-3-test.js
@@ -1,0 +1,336 @@
+import MobiledocRenderer, { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
+import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
+import { normalizeTagName } from 'mobiledoc-kit/utils/dom-utils';
+import Helpers from '../../../test-helpers';
+
+const { module, test } = Helpers;
+function render(post) {
+  return MobiledocRenderer.render(post);
+}
+let builder;
+
+module('Unit: Mobiledoc Renderer 0.3', {
+  beforeEach() {
+    builder = new PostNodeBuilder();
+  }
+});
+
+test('renders a blank post', (assert) => {
+  let post = builder.createPost();
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: []
+  });
+});
+
+test('renders a post with marker', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
+    return post([
+      markupSection('p', [marker('Hi', [markup('strong')])])
+    ]);
+  });
+  const mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [['strong']],
+    sections: [
+      [1, normalizeTagName('P'), [[0, [0], 1, 'Hi']]]
+    ]
+  });
+});
+
+test('renders a post section with markers sharing a markup', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
+    const strong = markup('strong');
+    return post([
+      markupSection('p', [marker('Hi', [strong]), marker(' Guy', [strong])])
+    ]);
+  });
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [['strong']],
+    sections: [
+      [1, normalizeTagName('P'), [
+        [0, [0], 0, 'Hi'],
+        [0, [], 1, ' Guy']
+      ]]
+    ]
+  });
+});
+
+test('renders a post with markers with markers with complex attributes', (assert) => {
+  let link1,link2;
+ const post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
+    link1 = markup('a', {href:'bustle.com'});
+    link2 = markup('a', {href:'other.com'});
+    return post([
+      markupSection('p', [
+        marker('Hi', [link1]),
+        marker(' Guy', [link2]),
+        marker(' other guy', [link1])
+      ])
+    ]);
+  });
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [
+      ['a', ['href', 'bustle.com']],
+      ['a', ['href', 'other.com']]
+    ],
+    sections: [
+      [1, normalizeTagName('P'), [
+        [0, [0], 1, 'Hi'],
+        [0, [1], 1, ' Guy'],
+        [0, [0], 1, ' other guy']
+      ]]
+    ]
+  });
+
+});
+
+
+test('renders a post with image', (assert) => {
+  let url = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
+  let post = builder.createPost();
+  let section = builder.createImageSection(url);
+  post.sections.append(section);
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [2, url]
+    ]
+  });
+});
+
+test('renders a post with image and null src', (assert) => {
+  let post = builder.createPost();
+  let section = builder.createImageSection();
+  post.sections.append(section);
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [2, null]
+    ]
+  });
+});
+
+test('renders a post with atom', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker, atom}) => {
+     return post([
+       markupSection('p', [
+         marker('Hi'),
+         atom('mention', '@bob', { id: 42 })
+       ])
+     ]);
+   });
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [
+      ['mention', '@bob', { id: 42 }]
+    ],
+    cards: [],
+    markups: [],
+    sections: [
+      [1, normalizeTagName('P'), [
+        [0, [], 0, 'Hi'],
+        [1, [], 0, 0]
+      ]]
+    ]
+  });
+});
+
+test('renders a post with atom and markup', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker, markup, atom}) => {
+    const strong = markup('strong');
+    return post([
+      markupSection('p', [
+        atom('mention', '@bob', { id: 42 }, [strong])
+      ])
+    ]);
+  });
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [
+      ['mention', '@bob', { id: 42 }]
+    ],
+    cards: [],
+    markups: [['strong']],
+    sections: [
+      [1, normalizeTagName('P'), [
+        [1, [0], 1, 0]
+      ]]
+    ]
+  });
+});
+
+test('renders a post with atom inside markup', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker, markup, atom}) => {
+    const strong = markup('strong');
+    return post([
+      markupSection('p', [
+        marker('Hi ', [strong]),
+        atom('mention', '@bob', { id: 42 }, [strong]),
+        marker(' Bye', [strong])
+      ])
+    ]);
+  });
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [
+      ['mention', '@bob', { id: 42 }]
+    ],
+    cards: [],
+    markups: [['strong']],
+    sections: [
+      [1, normalizeTagName('P'), [
+        [0, [0], 0, 'Hi '],
+        [1, [], 0, 0],
+        [0, [], 1, ' Bye']
+      ]]
+    ]
+  });
+});
+
+test('renders a post with card', (assert) => {
+  let cardName = 'super-card';
+  let payload = { bar: 'baz' };
+  let post = builder.createPost();
+  let section = builder.createCardSection(cardName, payload);
+  post.sections.append(section);
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [
+      [cardName, payload]
+    ],
+    markups: [],
+    sections: [
+      [10, 0]
+    ]
+  });
+});
+
+test('renders a post with multiple cards with identical payloads', (assert) => {
+  let cardName = 'super-card';
+  let payload1 = { bar: 'baz' };
+  let payload2 = { bar: 'baz' };
+  let post = builder.createPost();
+
+  let section1 = builder.createCardSection(cardName, payload1);
+  post.sections.append(section1);
+
+  let section2 = builder.createCardSection(cardName, payload2);
+  post.sections.append(section2);
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [
+      [cardName, payload1],
+      [cardName, payload2]
+    ],
+    markups: [],
+    sections: [
+      [10, 0],
+      [10, 1]
+    ]
+  });
+});
+
+test('renders a post with cards with differing payloads', (assert) => {
+  let cardName = 'super-card';
+  let payload1 = { bar: 'baz1' };
+  let payload2 = { bar: 'baz2' };
+  let post = builder.createPost();
+
+  let section1 = builder.createCardSection(cardName, payload1);
+  post.sections.append(section1);
+
+  let section2 = builder.createCardSection(cardName, payload2);
+  post.sections.append(section2);
+
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [
+      [cardName, payload1],
+      [cardName, payload2]
+    ],
+    markups: [],
+    sections: [
+      [10, 0],
+      [10, 1]
+    ]
+  });
+});
+
+test('renders a post with a list', (assert) => {
+  const items = [
+    builder.createListItem([builder.createMarker('first item')]),
+    builder.createListItem([builder.createMarker('second item')])
+  ];
+  const section = builder.createListSection('ul', items);
+  const post = builder.createPost([section]);
+
+  const mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [3, 'ul', [
+        [[0, [], 0, 'first item']],
+        [[0, [], 0, 'second item']]
+      ]]
+    ]
+  });
+});
+
+test('renders a pull-quote as markup section', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([markupSection('pull-quote', [marker('abc')])]);
+  });
+  const mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [1, 'pull-quote', [[0, [], 0, 'abc']]]
+    ]
+  });
+});


### PR DESCRIPTION
rebased/squashed version of #226 

*do not merge*. some tests to fix in FF and a some code/commit cleanup to do still.

This adds tests for all the cases mentioned in https://github.com/bustlelabs/mobiledoc-kit/pull/226#issuecomment-173630690.

Still to do:

 * [ ] fix 4 failing tests in FF

changelog summary

  * Atom model
  * First stab at rendering cards with editor-dom renderer
  * Atoms have length of 1
  * Atoms use DocumentFragment to render
  * Clear child nodes in AtomNode teardown
  * Use -mobiledoc-kit__atom for atom className
  * Atoms and Markers are both Markerupable
  * Implement Mobiledoc renderer v0.3 with atom support
  * Implement Mobiledoc parser for v0.3.0 format
  * Don’t de-duplicate cards/atoms based on payload
  * Export the right version from 0.3 renderer
  * Implement unknownAtomHandler & lifecycle hooks
  * Convert demo cards to 0.3.0 format, add an example Atom
  * Atoms should not be editable
  * Atoms with cursor movement, reparsing
  * Make Mobiledoc 0.3 the default version

  * Atom deletion with keystrokes

  * Document and test insertMarkers for atoms

  * Copy tweaks for atoms

  * Atom splitting/cloning for section edits

  * Properly parse and render atom markup

  * Change cursor#_findNodeForPosition to target the textnode after an
    atom's ending zwnj when there is one.
  * change the editor keyDown handler to reposition the cursor onto
    that next text node.
  * Change dom parsing to read text content out of the zwnj on either
    side of an atom and merge it into the before/after marker (or create new
  * marker(s) to accept that text)
  * Changes lifecycle callbacks #addCallbackOnce method to remove the
    once-added callback after flushing that queue

  * add tests for content in atom headTextNode with nothing or marker before it
  * test for atom headTextNode with atom before it, tailTextNode with nothing after it
  * test tailTextNode with atom, marker after it

  * update mentionAtom mobiledoc with more atoms

  * Tests for markupSection#length

  * fix mentionAtom mobiledoc, make it default in demo

 * change _findCursorForPosition to focus on atom markers properly
 * dom parser marks sections dirty when adding a new marker
 * postEditor#deleteBackwardFrom removes atom marker appropriately

  * Fix section.markersFor bug that truncated atom values, ctr-A, ctr-E

  * fix bug with adding markup to a single atom

  * add image-atom with inline image

  * Add tests for complex atom (re-)rendering, refactor editor-dom renderer

  * test that atoms are not coalesced. change marker.isEmpty -> marker.isBlank usage

  * add atom#splitAtOffset
  * remove marker#join
  * add `canJoin` to atom and marker

  * add null properties to renderNode
  * Tests for inserting text in/around atoms, and reparsing atoms

  * Test for arrow movement across atoms

  * Demo: Update renderers, add html image-atom

  * Test that selected text that includes/surrounds atoms can be deleted