### PR TITLE
Use `node.contains` instead of checking element.parentNode in mutations

### DIFF
--- a/src/js/editor/mutation-handler.js
+++ b/src/js/editor/mutation-handler.js
@@ -116,7 +116,8 @@ export default class MutationHandler {
         break;
     }
 
-    let attachedNodes = filter(nodes, node => !!node.parentNode);
+    let element = this.editor.element;
+    let attachedNodes = filter(nodes, node => element.contains(node));
     return attachedNodes;
   }
 


### PR DESCRIPTION
We used to check if an element had a null parent, but it is possible to
have an existing parent but still be out of dom (with a null grand*-parent)