### PR TITLE
WIP Undo redo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ editor.render(element);
 * `placeholder` - [string] default text to show before a user starts typing.
 * `spellcheck` - [boolean] whether to enable spellcheck. Defaults to true.
 * `autofocus` - [boolean] When true, focuses on the editor when it is rendered.
+* `undoDepth` - [number] How many undo levels should be available. Default
+  value is five. Set this to zero to disable undo/redo.
 * `cards` - [array] The list of cards that the editor may render
 * `atoms` - [array] The list of atoms that the editor may render
 * `cardOptions` - [object] Options passed to cards and atoms
-* `unknownCardHandler` - [function] This will be invoked by the editor-renderer whenever it encounters an unknown card
-* `unknownAtomHandler` - [function] This will be invoked by the editor-renderer whenever it encounters an unknown atom
+* `unknownCardHandler` - [function] This will be invoked by the editor-renderer
+  whenever it encounters an unknown card
+* `unknownAtomHandler` - [function] This will be invoked by the editor-renderer
+  whenever it encounters an unknown atom
 
 ### Editor API
 

--- a/demo/app/controllers/index.js
+++ b/demo/app/controllers/index.js
@@ -7,7 +7,7 @@ let { $ } = Ember;
 export default Ember.Controller.extend({
   init() {
     this._super.apply(this, arguments);
-    let mobiledoc = mobiledocs['mentionAtom'];
+    let mobiledoc = mobiledocs['simple'];
     this.set('mobiledoc', mobiledoc);
     this.set('editedMobiledoc', mobiledoc);
     this.set('rendererName', 'dom');

--- a/src/js/editor/edit-history.js
+++ b/src/js/editor/edit-history.js
@@ -1,0 +1,119 @@
+import mobiledocParsers from 'mobiledoc-kit/parsers/mobiledoc';
+import Range from 'mobiledoc-kit/utils/cursor/range';
+import Position from 'mobiledoc-kit/utils/cursor/position';
+import FixedQueue from 'mobiledoc-kit/utils/fixed-queue';
+
+function findLeafSectionAtIndex(post, index) {
+  let section;
+  post.walkAllLeafSections((_section, _index) => {
+    if (index === _index) {
+      section = _section;
+    }
+  });
+  return section;
+}
+
+export class Snapshot {
+  constructor(editor) {
+    this.mobiledoc = editor.serialize();
+    this.editor = editor;
+
+    this.snapshotRange();
+  }
+
+  snapshotRange() {
+    let { range, cursor } = this.editor;
+    if (cursor.hasCursor()) {
+      let { head, tail } = range;
+      this.range = {
+        head: [head.leafSectionIndex, head.offset],
+        tail: [tail.leafSectionIndex, tail.offset]
+      };
+    }
+  }
+
+  getRange(post) {
+    if (this.range) {
+      let { head, tail } = this.range;
+      let [headLeafSectionIndex, headOffset] = head;
+      let [tailLeafSectionIndex, tailOffset] = tail;
+      let headSection = findLeafSectionAtIndex(post, headLeafSectionIndex);
+      let tailSection = findLeafSectionAtIndex(post, tailLeafSectionIndex);
+
+      return new Range(new Position(headSection, headOffset),
+                       new Position(tailSection, tailOffset));
+    }
+  }
+}
+
+export default class EditHistory {
+  constructor(editor, queueLength) {
+    this.editor = editor;
+    this._undoStack = new FixedQueue(queueLength);
+    this._redoStack = new FixedQueue(queueLength);
+
+    this._pendingSnapshot = null;
+  }
+
+  snapshot() {
+    // update the current snapshot with the range read from DOM
+    if (this._pendingSnapshot) {
+      this._pendingSnapshot.snapshotRange();
+    }
+  }
+
+  storeSnapshot() {
+    // store pending snapshot
+    if (this._pendingSnapshot) {
+      this._undoStack.push(this._pendingSnapshot);
+      this._redoStack.clear();
+    }
+
+    // take new pending snapshot to store next time `storeSnapshot` is called
+    this._pendingSnapshot = new Snapshot(this.editor);
+  }
+
+  stepBackward(postEditor) {
+    // Throw away the pending snapshot
+    this._pendingSnapshot = null;
+
+    let snapshot = this._undoStack.pop();
+    if (snapshot) {
+      this._redoStack.push(new Snapshot(this.editor));
+      this._restoreFromSnapshot(snapshot, postEditor);
+    }
+  }
+
+  stepForward(postEditor) {
+    let snapshot = this._redoStack.pop();
+    if (snapshot) {
+      this._undoStack.push(new Snapshot(this.editor));
+      this._restoreFromSnapshot(snapshot, postEditor);
+    }
+    postEditor.cancelSnapshot();
+  }
+
+  _restoreFromSnapshot(snapshot, postEditor) {
+    let { mobiledoc } = snapshot;
+    let { editor } = this;
+    let { builder, post } = editor;
+    let restoredPost = mobiledocParsers.parse(builder, mobiledoc);
+
+    // remove existing sections
+    post.sections.toArray().forEach(section => {
+      postEditor.removeSection(section);
+    });
+
+    // append restored sections
+    restoredPost.sections.toArray().forEach(section => {
+      restoredPost.sections.remove(section);
+      postEditor.insertSectionBefore(post.sections, section, null);
+    });
+
+    // resurrect snapshotted range if it exists
+    let newRange = snapshot.getRange(post);
+    if (newRange) {
+      postEditor.setRange(newRange);
+    }
+  }
+}

--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -104,6 +104,20 @@ export const DEFAULT_KEY_COMMANDS = [{
       });
     }
   }
+}, {
+  str: 'META+Z',
+  run(editor) {
+    editor.run(postEditor => {
+      postEditor.undoLastChange();
+    });
+  }
+}, {
+  str: 'META+SHIFT+Z',
+  run(editor) {
+    editor.run(postEditor => {
+      postEditor.redoLastChange();
+    });
+  }
 }];
 
 function modifierNamesToMask(modiferNames) {

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -1261,6 +1261,18 @@ class PostEditor {
     // will read the dom
     this.editor.range = null;
   }
+
+  undoLastChange() {
+    this.editor._editHistory.stepBackward(this);
+  }
+
+  redoLastChange() {
+    this.editor._editHistory.stepForward(this);
+  }
+
+  cancelSnapshot() {
+    this._shouldCancelSnapshot = true;
+  }
 }
 
 mixin(PostEditor, LifecycleCallbacksMixin);

--- a/src/js/models/list-item.js
+++ b/src/js/models/list-item.js
@@ -41,4 +41,8 @@ export default class ListItem extends Markerable {
     this.markers.forEach(m => item.markers.append(m.clone()));
     return item;
   }
+
+  get post() {
+    return this.section.post;
+  }
 }

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -83,6 +83,17 @@ const Position = class Position {
     return new Position(this.section, this.offset);
   }
 
+  get leafSectionIndex() {
+    let post = this.section.post;
+    let leafSectionIndex;
+    post.walkAllLeafSections((section, index) => {
+      if (section === this.section) {
+        leafSectionIndex = index;
+      }
+    });
+    return leafSectionIndex;
+  }
+
   get isMarkerable() {
     return this.section && this.section.isMarkerable;
   }

--- a/src/js/utils/fixed-queue.js
+++ b/src/js/utils/fixed-queue.js
@@ -1,0 +1,29 @@
+export default class FixedQueue {
+  constructor(length=0) {
+    this._maxLength = length;
+    this._items = [];
+  }
+
+  get length() {
+    return this._items.length;
+  }
+
+  pop() {
+    return this._items.pop();
+  }
+
+  push(item) {
+    this._items.push(item);
+    if (this.length > this._maxLength) {
+      this._items.shift();
+    }
+  }
+
+  clear() {
+    this._items = [];
+  }
+
+  toArray() {
+    return this._items;
+  }
+}

--- a/tests/acceptance/editor-undo-redo-test.js
+++ b/tests/acceptance/editor-undo-redo-test.js
@@ -1,0 +1,290 @@
+import { MODIFIERS } from 'mobiledoc-kit/utils/key';
+import Helpers from '../test-helpers';
+import Position from 'mobiledoc-kit/utils/cursor/position';
+
+const { module, test } = Helpers;
+
+let editor, editorElement;
+
+function undo(editor) {
+  Helpers.dom.triggerKeyCommand(editor, 'Z', [MODIFIERS.META]);
+}
+
+function redo(editor) {
+  Helpers.dom.triggerKeyCommand(editor, 'Z', [MODIFIERS.META, MODIFIERS.SHIFT]);
+}
+
+module('Acceptance: Editor: Undo/Redo', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+  afterEach() {
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
+  }
+});
+
+test('undo/redo the insertion of a character', (assert) => {
+  let done = assert.async();
+  let expectedBeforeUndo, expectedAfterUndo;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expectedBeforeUndo = post([markupSection('p', [marker('abcD')])]);
+    expectedAfterUndo = post([markupSection('p', [marker('abc')])]);
+    return expectedAfterUndo;
+  });
+
+  let textNode = Helpers.dom.findTextNode(editorElement, 'abc');
+  Helpers.dom.moveCursorTo(textNode, 'abc'.length);
+
+  Helpers.dom.insertText(editor, 'D');
+
+  setTimeout(()  => {
+    assert.postIsSimilar(editor.post, expectedBeforeUndo); // precond
+    undo(editor);
+    assert.postIsSimilar(editor.post, expectedAfterUndo);
+    assert.renderTreeIsEqual(editor._renderTree, expectedAfterUndo);
+
+    let position = editor.range.head;
+    assert.positionIsEqual(position, editor.post.sections.head.tailPosition());
+
+    redo(editor);
+
+    assert.postIsSimilar(editor.post, expectedBeforeUndo);
+    assert.renderTreeIsEqual(editor._renderTree, expectedBeforeUndo);
+
+    position = editor.range.head;
+    assert.positionIsEqual(position, editor.post.sections.head.tailPosition());
+
+    done();
+  });
+});
+
+// Test to ensure that we don't push empty snapshots on the undo stack
+// when typing characters
+test('undo/redo the insertion of multiple characters', (assert) => {
+  let done = assert.async();
+  let beforeUndo, afterUndo1, afterUndo2;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    beforeUndo = post([markupSection('p', [marker('abcDE')])]);
+    afterUndo1 = post([markupSection('p', [marker('abcD')])]);
+    afterUndo2 = post([markupSection('p', [marker('abc')])]);
+    return afterUndo2;
+  });
+
+  let textNode = Helpers.dom.findTextNode(editorElement, 'abc');
+  Helpers.dom.moveCursorTo(textNode, 'abc'.length);
+
+  Helpers.dom.insertText(editor, 'D');
+
+  setTimeout(()  => {
+    Helpers.dom.insertText(editor, 'E');
+
+    setTimeout(()  => {
+      assert.postIsSimilar(editor.post, beforeUndo); // precond
+
+      undo(editor);
+      assert.postIsSimilar(editor.post, afterUndo1);
+
+      undo(editor);
+      assert.postIsSimilar(editor.post, afterUndo2);
+
+      redo(editor);
+      assert.postIsSimilar(editor.post, afterUndo1);
+
+      redo(editor);
+      assert.postIsSimilar(editor.post, beforeUndo);
+      done();
+    });
+  });
+});
+
+test('undo the deletion of a character', (assert) => {
+  let expectedBeforeUndo, expectedAfterUndo;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expectedBeforeUndo = post([markupSection('p', [marker('abc')])]);
+    expectedAfterUndo = post([markupSection('p', [marker('abcD')])]);
+    return expectedAfterUndo;
+  });
+
+  let textNode = Helpers.dom.findTextNode(editorElement, 'abcD');
+  Helpers.dom.moveCursorTo(textNode, 'abcD'.length);
+
+  Helpers.dom.triggerDelete(editor);
+
+  assert.postIsSimilar(editor.post, expectedBeforeUndo); // precond
+
+  undo(editor);
+  assert.postIsSimilar(editor.post, expectedAfterUndo);
+  assert.renderTreeIsEqual(editor._renderTree, expectedAfterUndo);
+  let position = editor.range.head;
+  assert.positionIsEqual(position, editor.post.sections.head.tailPosition());
+
+  redo(editor);
+  assert.postIsSimilar(editor.post, expectedBeforeUndo);
+  assert.renderTreeIsEqual(editor._renderTree, expectedBeforeUndo);
+  position = editor.range.head;
+  assert.positionIsEqual(position, editor.post.sections.head.tailPosition());
+});
+
+test('undo the deletion of a range', (assert) => {
+  let expectedBeforeUndo, expectedAfterUndo;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expectedBeforeUndo = post([markupSection('p', [marker('ad')])]);
+    expectedAfterUndo = post([markupSection('p', [marker('abcd')])]);
+    return expectedAfterUndo;
+  });
+
+  Helpers.dom.selectText('bc', editorElement);
+  Helpers.dom.triggerDelete(editor);
+
+  assert.postIsSimilar(editor.post, expectedBeforeUndo); // precond
+
+  undo(editor);
+  assert.postIsSimilar(editor.post, expectedAfterUndo);
+  assert.renderTreeIsEqual(editor._renderTree, expectedAfterUndo);
+  let { head, tail } = editor.range;
+  let section = editor.post.sections.head;
+  assert.positionIsEqual(head, new Position(section, 'a'.length));
+  assert.positionIsEqual(tail, new Position(section, 'abc'.length));
+
+  redo(editor);
+  assert.postIsSimilar(editor.post, expectedBeforeUndo);
+  assert.renderTreeIsEqual(editor._renderTree, expectedBeforeUndo);
+  head = editor.range.head;
+  tail = editor.range.tail;
+  section = editor.post.sections.head;
+  assert.positionIsEqual(head, new Position(section, 'a'.length));
+  assert.positionIsEqual(tail, new Position(section, 'a'.length));
+});
+
+test('undo insertion of character to a list item', (assert) => {
+  let done = assert.async();
+  let expectedBeforeUndo, expectedAfterUndo;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, listSection, listItem, marker}) => {
+    expectedBeforeUndo = post([
+      listSection('ul', [listItem([marker('abcD')])])
+    ]);
+    expectedAfterUndo = post([
+      listSection('ul', [listItem([marker('abc')])])
+    ]);
+    return expectedAfterUndo;
+  });
+
+  let textNode = Helpers.dom.findTextNode(editorElement, 'abc');
+  Helpers.dom.moveCursorTo(textNode, 'abc'.length);
+  Helpers.dom.insertText(editor, 'D');
+
+  setTimeout(() => {
+    assert.postIsSimilar(editor.post, expectedBeforeUndo); // precond
+
+    undo(editor);
+    assert.postIsSimilar(editor.post, expectedAfterUndo);
+    assert.renderTreeIsEqual(editor._renderTree, expectedAfterUndo);
+    let { head, tail } = editor.range;
+    let section = editor.post.sections.head.items.head;
+    assert.positionIsEqual(head, new Position(section, 'abc'.length));
+    assert.positionIsEqual(tail, new Position(section, 'abc'.length));
+
+    redo(editor);
+    assert.postIsSimilar(editor.post, expectedBeforeUndo);
+    assert.renderTreeIsEqual(editor._renderTree, expectedBeforeUndo);
+    head = editor.range.head;
+    tail = editor.range.tail;
+    section = editor.post.sections.head.items.head;
+    assert.positionIsEqual(head, new Position(section, 'abcD'.length));
+    assert.positionIsEqual(tail, new Position(section, 'abcD'.length));
+
+    done();
+  });
+});
+
+test('undo stack length can be configured', (assert) => {
+  let done = assert.async();
+  let editorOptions = { undoDepth: 1 };
+
+  let beforeUndo, afterUndo;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+     beforeUndo = post([markupSection('p', [marker('abcDE')])]);
+     afterUndo = post([markupSection('p', [marker('abcD')])]);
+     return post([markupSection('p', [marker('abc')])]);
+  }, editorOptions);
+
+  let textNode = Helpers.dom.findTextNode(editorElement, 'abc');
+  Helpers.dom.moveCursorTo(textNode, 'abc'.length);
+  Helpers.dom.insertText(editor, 'D');
+
+  setTimeout(() => {
+    Helpers.dom.insertText(editor, 'E');
+
+    setTimeout(() => {
+      assert.postIsSimilar(editor.post, beforeUndo); // precond
+
+      undo(editor);
+      assert.postIsSimilar(editor.post, afterUndo);
+      assert.renderTreeIsEqual(editor._renderTree, afterUndo);
+      assert.positionIsEqual(editor.range.head, editor.post.sections.head.tailPosition());
+
+      undo(editor);
+      assert.postIsSimilar(editor.post, afterUndo, 'second undo does not change post');
+      assert.renderTreeIsEqual(editor._renderTree, afterUndo);
+      assert.positionIsEqual(editor.range.head, editor.post.sections.head.tailPosition());
+
+      done();
+    });
+  });
+});
+
+test('undo stack length can be configured', (assert) => {
+  let done = assert.async();
+  let editorOptions = { undoDepth: 0 };
+
+  let beforeUndo;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+     beforeUndo = post([markupSection('p', [marker('abcDE')])]);
+     return post([markupSection('p', [marker('abc')])]);
+  }, editorOptions);
+
+  let textNode = Helpers.dom.findTextNode(editorElement, 'abc');
+  Helpers.dom.moveCursorTo(textNode, 'abc'.length);
+  Helpers.dom.insertText(editor, 'D');
+
+  setTimeout(() => {
+    Helpers.dom.insertText(editor, 'E');
+
+    setTimeout(() => {
+      assert.postIsSimilar(editor.post, beforeUndo); // precond
+
+      undo(editor);
+      assert.postIsSimilar(editor.post, beforeUndo, 'nothing is undone');
+      assert.renderTreeIsEqual(editor._renderTree, beforeUndo);
+      assert.positionIsEqual(editor.range.head, editor.post.sections.head.tailPosition());
+
+      done();
+    });
+  });
+
+});
+
+test('taking and restoring a snapshot with no cursor', (assert) => {
+  let beforeUndo, afterUndo;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+     beforeUndo = post([markupSection('p', [marker('abc')])]);
+     afterUndo = post([markupSection('p', [])]);
+     return afterUndo;
+  }, {autofocus: false});
+
+  assert.ok(!editor.cursor.hasCursor(), 'precond - no cursor');
+  editor.run(postEditor => {
+    postEditor.insertText(editor.post.headPosition(), 'abc');
+  });
+  assert.postIsSimilar(editor.post, beforeUndo, 'precond - text is added');
+
+  undo(editor);
+  assert.postIsSimilar(editor.post, afterUndo, 'text is removed');
+});
+
+// FIXME test that the queue length is respected (only 5 undoes or redoes)
+// FIXME test that making a change clears the redo queue
+// FIXME test undoing, redoing, undoing again

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -1,5 +1,5 @@
 import { clearSelection } from 'mobiledoc-kit/utils/selection-utils';
-import { forEach } from 'mobiledoc-kit/utils/array-utils';
+import { forEach, contains } from 'mobiledoc-kit/utils/array-utils';
 import KEY_CODES from 'mobiledoc-kit/utils/keycodes';
 import { DIRECTION, MODIFIERS }  from 'mobiledoc-kit/utils/key';
 import { isTextNode } from 'mobiledoc-kit/utils/dom-utils';
@@ -226,11 +226,15 @@ function insertText(editor, string) {
 
 // triggers a key sequence like cmd-B on the editor, to test out
 // registered keyCommands
-function triggerKeyCommand(editor, string, modifier) {
+function triggerKeyCommand(editor, string, modifiers=[]) {
+  if (typeof modifiers === "number") {
+    modifiers = [modifiers]; // convert singular to array
+  }
   let keyEvent = createMockEvent('keydown', editor.element, {
     keyCode: string.toUpperCase().charCodeAt(0),
-    metaKey: modifier === MODIFIERS.META,
-    ctrlKey: modifier === MODIFIERS.CTRL
+    shiftKey: contains(modifiers, MODIFIERS.SHIFT),
+    metaKey: contains(modifiers, MODIFIERS.META),
+    ctrlKey: contains(modifiers, MODIFIERS.CTRL)
   });
   editor.triggerEvent(editor.element, 'keydown', keyEvent);
 }
@@ -313,6 +317,12 @@ function fromHTML(html) {
   return div;
 }
 
+function findTextNode(parentElement, text) {
+  return walkDOMUntil(parentElement, node => {
+    return isTextNode(node) && node.textContent.indexOf(text) !== -1;
+  });
+}
+
 const DOMHelper = {
   moveCursorTo,
   selectRange,
@@ -337,7 +347,8 @@ const DOMHelper = {
   getCopyData,
   setCopyData,
   clearCopyData,
-  createMockEvent
+  createMockEvent,
+  findTextNode
 };
 
 export { triggerEvent };

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -114,6 +114,28 @@ test('#walkMarkerableSections skips non-markerable sections', (assert) => {
 
 });
 
+test('#walkAllLeafSections returns markup section that follows a list section', (assert) => {
+  let post = Helpers.postAbstract.build(({post, markupSection, marker, listSection, listItem}) => {
+    return post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('def')]),
+      listSection('ul', [
+        listItem([marker('123')])
+      ]),
+      markupSection('p')
+    ]);
+  });
+
+  let sections = [];
+  post.walkAllLeafSections(s => sections.push(s));
+
+  assert.equal(sections.length, 4);
+  assert.ok(sections[0] === post.sections.head, 'section 0');
+  assert.ok(sections[1] === post.sections.objectAt(1), 'section 1');
+  assert.ok(sections[2] === post.sections.objectAt(2).items.head, 'section 2');
+  assert.ok(sections[3] === post.sections.tail, 'section 3');
+});
+
 test('#markupsInRange returns all markups', (assert) => {
   let b, i, a1, a2, found;
   const post = Helpers.postAbstract.build(builder => {

--- a/tests/unit/utils/fixed-queue-test.js
+++ b/tests/unit/utils/fixed-queue-test.js
@@ -1,0 +1,40 @@
+import Helpers from '../../test-helpers';
+import FixedQueue from 'mobiledoc-kit/utils/fixed-queue';
+
+const {module, test} = Helpers;
+
+module('Unit: Utils: FixedQueue');
+
+test('basic implementation', (assert) => {
+  let queue = new FixedQueue(3);
+  for (let i=0; i < 3; i++) {
+    queue.push(i);
+  }
+
+  assert.equal(queue.length, 3);
+
+  let popped = [];
+  while (queue.length) {
+    popped.push(queue.pop());
+  }
+
+  assert.deepEqual(popped, [2,1,0]);
+});
+
+test('empty queue', (assert) => {
+  let queue = new FixedQueue(0);
+  assert.equal(queue.length, 0);
+  assert.equal(queue.pop(), undefined);
+  queue.push(1);
+
+  assert.equal(queue.length, 0);
+  assert.deepEqual(queue.toArray(), []);
+});
+
+test('push onto full queue ejects first item', (assert) => {
+  let queue = new FixedQueue(1);
+  queue.push(0);
+  queue.push(1);
+
+  assert.deepEqual(queue.toArray(), [1]);
+});


### PR DESCRIPTION
*do not merge*

Beginning work to enable a naive version of undo/redo in Mobiledoc-Kit. This stores a snapshot (including the cursor position when possible) when changing the mobiledoc (specifically in `editor.run`).

A few things to do:
  * [x] basic tests for undoability
  * [x] limit the undo stack to reduce memory pressure
  * [ ] look at and test edge cases relating to the post (list items, cards, atoms)
  * [ ] test dragging text in and hitting undo (change the textContent of a node, setTimeout to allow the parser, then assert) 
  * [x] look at and test edge cases for positioning (when the position cannot be determined, i.e., editor does not have focus and user clicks a button to add a card)
  * [x] look at and test edge cases related to mutation handling (dragging in a single word or multiple sections)
  * [x] implement a redo stack
  * [x] allow configuring the length of the undo/redo stack