### PR TITLE
Separate testem configs for local tests and saucelabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "5.4.1"
 
 sudo: false
 
@@ -10,13 +10,13 @@ cache:
     - node_modules
 
 before_install:
-  # See https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to
-  # modified to not use sudo (just puts $PWD on the path so that $PWD/phantomjs is the phantom used
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xjf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - export PATH=$PWD:$PATH
+  # See https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+  - echo $(phantomjs --version)
   - npm config set spin false
-  - npm install -g npm@^2
 
 install:
   - npm install -g broccoli-cli
@@ -25,7 +25,7 @@ install:
   - npm install
 
 script:
-  - npm test
+  - npm run test:ci
 
 env:
-  - SAUCE_USERNAME=yoran SAUCE_ACCESS_KEY=87144ef7-569c-44b1-a11e-9c9c28c40780
+  - SAUCE_USERNAME=mobiledoc-kit SAUCE_ACCESS_KEY=f9cad21d-1141-452d-8f64-c6ba3f43faa6

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## Mobiledoc Kit [![Build Status](https://travis-ci.org/bustlelabs/mobiledoc-kit.svg?branch=master)](https://travis-ci.org/bustlelabs/mobiledoc-kit)
+## Mobiledoc Kit
+
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/mobiledoc-kit.svg)](https://saucelabs.com/u/mobiledoc-kit)
 
 ![Mobiledoc Logo](https://raw.githubusercontent.com/bustlelabs/mobiledoc-kit/master/demo/public/images/mobiledoc-logo-color-small.png)
 
@@ -277,6 +279,8 @@ Run tests via the built-in broccoli server:
 Or run headless tests via testem:
 
   * `npm test`
+
+Tests in CI are run at Travis via Saucelabs (see the `test:ci` npm script).
 
 #### Demo
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "https://github.com/bustlelabs/mobiledoc-kit",
   "scripts": {
     "start": "broccoli serve",
-    "test": "testem ci --port 8080",
+    "test:ci": "npm run build && testem ci -f testem-ci.json",
+    "test": "npm run build && testem ci -f testem.json",
     "build": "rm -rf dist && broccoli build dist",
     "build-website": "./bin/build-website.sh",
     "deploy-website": "./bin/deploy-website.sh",

--- a/testem-ci.json
+++ b/testem-ci.json
@@ -1,0 +1,51 @@
+{
+  "framework": "qunit",
+  "parallel": 6,
+  "test_page": "dist/tests/index.html",
+  "on_start": "./sauce_labs/saucie-connect.js",
+  "on_exit": "./sauce_labs/saucie-disconnect.js",
+  "port": 8080,
+  "src_files": [
+    "tests/**/*.js",
+    "src/**/*.js"
+  ],
+  "launchers": {
+    "SL_Chrome_Current": {
+      "exe": "saucie",
+      "args": ["-b", "chrome", "--no-ct", "-u"],
+      "protocol": "tap"
+    },
+    "SL_MS_Edge": {
+      "exe": "saucie",
+      "args": ["-b", "microsoftedge", "--no-ct", "-u"],
+      "protocol": "tap"
+    },
+    "SL_IE_11": {
+      "exe": "saucie",
+      "args": ["-b", "internet explorer", "-v", "11", "--no-ct", "-u"],
+      "protocol": "tap"
+    },
+    "SL_Firefox_Current": {
+      "exe": "saucie",
+      "args": ["-b", "firefox", "--no-ct", "-u"],
+      "protocol": "tap"
+    },
+    "SL_Safari_9": {
+      "exe": "saucie",
+      "args": ["-b", "safari", "-v", "9", "--no-ct", "-u"],
+      "protocol": "tap"
+    }
+  },
+  "launch_in_ci": [
+    "PhantomJS",
+    "SL_Chrome_Current",
+    "SL_MS_Edge",
+    "SL_IE_11",
+    "SL_Firefox_Current",
+    "SL_Safari_9"
+  ],
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
+  ]
+}

--- a/testem.json
+++ b/testem.json
@@ -1,48 +1,12 @@
 {
   "framework": "qunit",
-  "parallel": 5,
   "test_page": "dist/tests/index.html",
-  "on_start": "./sauce_labs/saucie-connect.js",
-  "on_exit": "./sauce_labs/saucie-disconnect.js",
   "src_files": [
     "tests/**/*.js",
     "src/**/*.js"
   ],
-  "before_tests": "npm run build",
-  "launchers": {
-    "SL_Chrome_Current": {
-      "exe": "saucie",
-      "args": ["-b", "chrome", "--no-ct", "-u"],
-      "protocol": "tap"
-    },
-    "SL_MS_Edge": {
-      "exe": "saucie",
-      "args": ["-b", "microsoftedge", "--no-ct", "-u"],
-      "protocol": "tap"
-    },
-    "SL_IE_11": {
-      "exe": "saucie",
-      "args": ["-b", "internet explorer", "-v", "11", "--no-ct", "-u"],
-      "protocol": "tap"
-    },
-    "SL_Firefox_Current": {
-      "exe": "saucie",
-      "args": ["-b", "firefox", "--no-ct", "-u"],
-      "protocol": "tap"
-    },
-    "SL_Safari_9": {
-      "exe": "saucie",
-      "args": ["-b", "safari", "-v", "9", "--no-ct", "-u"],
-      "protocol": "tap"
-    }
-  },
   "launch_in_ci": [
-    "PhantomJS",
-    "SL_Chrome_Current",
-    "SL_MS_Edge",
-    "SL_IE_11",
-    "SL_Firefox_Current",
-    "SL_Safari_9"
+    "PhantomJS"
   ],
   "launch_in_dev": [
     "PhantomJS",


### PR DESCRIPTION
Uses the mobiledoc-kit saucelabs, updates some settings in testem and travis

 * Separate testem configs for local tests and saucelabs
 * Add `npm test:ci` script
 * Use phantom 2.1.1, node 5.4.1