### PR TITLE
Ignore mutation events from within atoms

### DIFF
--- a/src/js/editor/mutation-handler.js
+++ b/src/js/editor/mutation-handler.js
@@ -1,7 +1,8 @@
 import Set from 'mobiledoc-kit/utils/set';
 import { forEach, filter } from 'mobiledoc-kit/utils/array-utils';
 import assert from 'mobiledoc-kit/utils/assert';
-import { containsNode } from 'mobiledoc-kit/utils/dom-utils';
+import { containsNode, closest } from 'mobiledoc-kit/utils/dom-utils';
+import { ATOM_CLASS_NAME } from 'mobiledoc-kit/renderers/editor-dom';
 
 const MUTATION = {
   NODES_CHANGED: 'childList',
@@ -122,7 +123,8 @@ export default class MutationHandler {
     }
 
     let element = this.editor.element;
-    let attachedNodes = filter(nodes, node => containsNode(element, node));
+    let atomClass = `.${ATOM_CLASS_NAME}`;
+    let attachedNodes = filter(nodes, node => containsNode(element, node) && !closest(node, atomClass, true));
     return attachedNodes;
   }
 

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -92,6 +92,25 @@ function parseHTML(html) {
   return div;
 }
 
+function closest(el, selector, contentOnly=false) {
+  if (!isElementNode(el)) {
+    el = el.parentElement;
+  }
+  var matchesSelector = el.matches || el.webkitMatchesSelector || el.mozMatchesSelector || el.msMatchesSelector;
+
+  if (contentOnly && matchesSelector.call(el, selector)) {
+    return null;
+  }
+
+  while (el) {
+    if (matchesSelector.call(el, selector)) {
+      break;
+    }
+    el = el.parentElement;
+  }
+  return el;
+}
+
 export {
   containsNode,
   clearChildNodes,
@@ -103,5 +122,6 @@ export {
   isTextNode,
   isCommentNode,
   isElementNode,
-  parseHTML
+  parseHTML,
+  closest
 };


### PR DESCRIPTION
ember-mobiledoc-editor uses ember-wormhole to insert components into 
atom placeholders. This immediately causes a mutation and then
the editor update is triggered when nothing has changed.

Atoms are their own world and so any changes in them should be safe
to ignore.