### PR TITLE
Handle `drop` event

### DIFF
--- a/demo/app/mobiledoc-cards/dom.js
+++ b/demo/app/mobiledoc-cards/dom.js
@@ -3,6 +3,7 @@ import simpleCard from './dom/simple';
 import selfieCard from './dom/selfie';
 import imageCard from './dom/image';
 import codemirrorCard from './dom/codemirror';
+import dragoverCard from './dom/dragover';
 import createComponentCard from 'ember-mobiledoc-editor/utils/create-component-card';
 
 export default [
@@ -11,5 +12,6 @@ export default [
   selfieCard,
   imageCard,
   codemirrorCard,
-  createComponentCard('ember-card')
+  createComponentCard('ember-card'),
+  dragoverCard
 ];

--- a/demo/app/mobiledoc-cards/dom/dragover.js
+++ b/demo/app/mobiledoc-cards/dom/dragover.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+
+let { $ } = Ember;
+
+export default {
+  name: 'dragover',
+  type: 'dom',
+  render({env, payload}) {
+    let color = payload.didDrop ? 'red' : (payload.didDrag ? 'green' : 'black');
+    let text = payload.didDrop ? 'dropped' : (payload.didDrag ? 'dragged' : 'nothing');
+    let div = $(`<div>${text}</div>`).css({
+      border: `2px solid ${color}`
+    });
+
+    if (env.isInEditor) {
+      div.on('dragover', function(event) {
+        event.preventDefault();
+
+        div.css({border: '2px solid green'}).text('DRAGOVER');
+        payload.didDrag = true;
+        env.save(payload);
+      });
+      div.on('drop', function(event) {
+        event.preventDefault();
+
+        div.css({border: '2px solid red'}).text('DROP');
+        payload.didDrop = true;
+        env.save(payload);
+      });
+    }
+
+    return div[0];
+  }
+};

--- a/demo/app/mobiledoc-cards/html.js
+++ b/demo/app/mobiledoc-cards/html.js
@@ -3,11 +3,13 @@ import selfie from './html/selfie';
 import simple from './html/simple';
 import image from './html/image';
 import codemirror from './html/codemirror';
+import dragoverCard from './html/dragover';
 
 export default [
   input,
   selfie,
   simple,
   image,
-  codemirror
+  codemirror,
+  dragoverCard
 ];

--- a/demo/app/mobiledoc-cards/html/dragover.js
+++ b/demo/app/mobiledoc-cards/html/dragover.js
@@ -1,0 +1,8 @@
+export default {
+  name: 'dragover',
+  type: 'html',
+  render({payload}) {
+    return 'Hello, ' + (payload.didDrop ? 'did drop' : 'did not drop') +
+      ', ' + (payload.didDrag ? 'did drag' : 'did not drag');
+  }
+};

--- a/demo/app/mobiledoc-cards/text.js
+++ b/demo/app/mobiledoc-cards/text.js
@@ -3,11 +3,13 @@ import simpleCard from './text/simple';
 import inputCard from './text/input';
 import imageCard from './text/image';
 import selfieCard from './text/selfie';
+import dragoverCard from './text/dragover';
 
 export default [
   codemirrorCard,
   simpleCard,
   inputCard,
   imageCard,
-  selfieCard
+  selfieCard,
+  dragoverCard
 ];

--- a/demo/app/mobiledoc-cards/text/dragover.js
+++ b/demo/app/mobiledoc-cards/text/dragover.js
@@ -1,0 +1,8 @@
+export default {
+  name: 'dragover',
+  type: 'text',
+  render({payload}) {
+    return 'Hello, ' + (payload.didDrop ? 'did drop' : 'did not drop') +
+      ', ' + (payload.didDrag ? 'did drag' : 'did not drag');
+  }
+};

--- a/demo/app/mobiledocs/index.js
+++ b/demo/app/mobiledocs/index.js
@@ -1,4 +1,21 @@
 export default {
+  dragover: {
+    version: '0.3.0',
+    atoms: [],
+    markups: [],
+    cards: [
+      ['dragover', {}]
+    ],
+    sections: [
+      [1, 'h2', [
+        [0, [], 0, 'Mention Atom']
+      ]],
+      [10, 0],
+      [1, 'P', [
+        [0, [], 0, 'some text'],
+      ]]
+    ]
+  },
   mentionAtom: {
     version: '0.3.0',
     atoms: [

--- a/demo/app/templates/index.hbs
+++ b/demo/app/templates/index.hbs
@@ -30,6 +30,7 @@
         <option value='selfieCard'>Selfie Card</option>
         <option value='codemirrorCard'>Codemirror Card</option>
         <option value='mentionAtom'>Mention Atom</option>
+        <option value='dragover'>Drag drop cards</option>
       </select>
       {{#mobiledoc-editor
           class='post-editor__editor'

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -20,6 +20,7 @@ import { setData } from '../utils/element-utils';
 import mixin from '../utils/mixin';
 import Cursor from '../utils/cursor';
 import Range from '../utils/cursor/range';
+import Position from '../utils/cursor/position';
 import PostNodeBuilder from '../models/post-node-builder';
 import {
   DEFAULT_TEXT_EXPANSIONS, findExpansion, validateExpansion
@@ -42,7 +43,8 @@ let log = Logger.for('editor'); /* jshint ignore:line */
 Logger.enableTypes([
   'mutation-handler',
   'event-manager',
-  'editor'
+  'editor',
+  'parse-utils'
 ]);
 Logger.disable();
 
@@ -729,6 +731,15 @@ class Editor {
 
       postEditor.insertTextWithMarkup(position, text, activeMarkups);
     });
+  }
+
+  /**
+   * @param {integer} x x-position in viewport
+   * @param {integer} y y-position in viewport
+   * @return {Position|null}
+   */
+  positionAtPoint(x, y) {
+    return Position.atPoint(x, y, this);
   }
 
   // @private

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -1,12 +1,12 @@
-import {
-  isTextNode
-} from 'mobiledoc-kit/utils/dom-utils';
+import { isTextNode } from 'mobiledoc-kit/utils/dom-utils';
 import { DIRECTION } from 'mobiledoc-kit/utils/key';
 import assert from 'mobiledoc-kit/utils/assert';
 import {
   HIGH_SURROGATE_RANGE,
   LOW_SURROGATE_RANGE
 } from 'mobiledoc-kit/models/marker';
+import { containsNode } from 'mobiledoc-kit/utils/dom-utils';
+import { findOffsetInNode } from 'mobiledoc-kit/utils/selection-utils';
 
 function findParentSectionFromNode(renderTree, node) {
   let renderNode =  renderTree.findRenderNodeFromElement(
@@ -65,6 +65,23 @@ const Position = class Position {
     this.section = section;
     this.offset = offset;
     this.isBlank = false;
+  }
+
+  /**
+   * @param {integer} x x-position in current viewport
+   * @param {integer} y y-position in current viewport
+   * @param {Editor} editor
+   * @return {Position|null}
+   */
+  static atPoint(x, y, editor) {
+    let { _renderTree, element: rootElement } = editor;
+    let elementFromPoint = document.elementFromPoint(x, y);
+    if (!containsNode(rootElement, elementFromPoint)) {
+      return;
+    }
+
+    let { node, offset } = findOffsetInNode(elementFromPoint, {left: x, top: y});
+    return Position.fromNode(_renderTree, node, offset);
   }
 
   static blankPosition() {

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -5,7 +5,7 @@ import { supportsStandardClipboardAPI } from '../helpers/browsers';
 import {
   MIME_TEXT_PLAIN,
   MIME_TEXT_HTML
-} from 'mobiledoc-kit/utils/paste-utils';
+} from 'mobiledoc-kit/utils/parse-utils';
 
 const { module, skipInIE11 } = Helpers;
 

--- a/tests/acceptance/editor-drag-drop-test.js
+++ b/tests/acceptance/editor-drag-drop-test.js
@@ -1,0 +1,60 @@
+import Helpers from '../test-helpers';
+
+const { module, test } = Helpers;
+
+let editor, editorElement;
+
+function findCenterPointOfTextNode(node) {
+  let range = document.createRange();
+  range.setStart(node, 0);
+  range.setEnd(node, node.textContent.length);
+
+  let {left, top, width, height} = range.getBoundingClientRect();
+
+  let clientX = left + width/2;
+  let clientY = top + height/2;
+
+  return {clientX, clientY};
+}
+
+module('Acceptance: editor: drag-drop', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+  afterEach() {
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
+  }
+});
+
+test('inserts dropped HTML content at the drop position', (assert) => {
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([markupSection('h2', [marker('--->some text<---')])]);
+    return post([markupSection('h2', [marker('---><---')])]);
+  });
+
+  let html = '<p>some text</p>';
+  let node = Helpers.dom.findTextNode(editorElement, '---><---');
+  let {clientX, clientY} = findCenterPointOfTextNode(node);
+  Helpers.dom.triggerDropEvent(editor, {html, clientX, clientY});
+
+  assert.postIsSimilar(editor.post, expected);
+});
+
+test('inserts dropped text content at the drop position if no html data', (assert) => {
+  let expected;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
+    expected = post([markupSection('h2', [marker('--->some text<---')])]);
+    return post([markupSection('h2', [marker('---><---')])]);
+  });
+
+  let text = 'some text';
+  let node = Helpers.dom.findTextNode(editorElement, '---><---');
+  let {clientX, clientY} = findCenterPointOfTextNode(node);
+  Helpers.dom.triggerDropEvent(editor, {text, clientX, clientY});
+
+  assert.postIsSimilar(editor.post, expected);
+});


### PR DESCRIPTION
Changes the editor to handle and prevent the default behavior for `drop` events. Before this change, the editor's `MutationObserver` would be used to detect DOM changes resulting from dropped content after-the-fact and clean up as well as possible.

This changes drop events to be handled in the same manner as all other non-mutation events, namely that they are handled and interpreted semantically by the `EventManager` and any necessary changes are applied to the post via the standard `editor.run()` mechanism.

This addresses #322 (partially) because it removes the only-known source of an entire post reparse.

Adds `Editor#positionAtPoint(x, y)` method that uses `document.elementFromPoint` and some positioning heuristics (inspired by the algorithm used by ProseMirror) to determine the logical `Position` in the post that a drop event occurs at. Uses `PostEditor#insertPost` to insert the post.

Also updates the demo app to include a demo with a card that handles drag/drop events (to demonstrate that the editor's `drop` listener does not interfere with drag/drop events on cards).

Notes:
  *  IE does not provide any usable content data in the `drop` event so we no-op on dropped content in IE.
  * The browser's native drop-target (cursor that follows the mouse position while dragging over the editor) is still rendered, but sometimes the native drop target cursor does not render at the same position that `Editor#positionAtPoint` will find for the `clientX`, `clientY` coordinates, resulting in possible user confusion. Most notable, the drop target cursor appears at the right side of text when the user drags over anything to the right of that section, but `positionAtPoint` will return the left side position (because the element returned by `document.elementFromPoint` is the containing div for that section). In practice this does seem to be as problematic as it may sound, but it is a place for further improvement (either improving the positioning heuristic or rendering our own drop-target cursor instead of the native browser one).