### PR TITLE
[CLEANUP] DRY copy/paste and drop event handling. Add editor#serializeTo

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -1,7 +1,7 @@
 import assert from 'mobiledoc-kit/utils/assert';
 import {
   parsePostFromPaste,
-  setClipboardCopyData,
+  setClipboardData,
   parsePostFromDrop
 } from 'mobiledoc-kit/utils/parse-utils';
 import Range from 'mobiledoc-kit/utils/cursor/range';
@@ -144,13 +144,25 @@ export default class EventManager {
   }
 
   cut(event) {
+    event.preventDefault();
+
     this.copy(event);
     this.editor.handleDeletion();
   }
 
   copy(event) {
     event.preventDefault();
-    setClipboardCopyData(event, this.editor);
+
+    let { editor, editor: { range, post } } = this;
+    post = post.trimTo(range);
+
+    let data = {
+      html: editor.serializePost(post, 'html'),
+      text: editor.serializePost(post, 'text'),
+      mobiledoc: editor.serializePost(post, 'mobiledoc')
+    };
+
+    setClipboardData(event, data, window);
   }
 
   paste(event) {
@@ -159,10 +171,6 @@ export default class EventManager {
     let { editor } = this;
     let range = editor.range;
 
-    // FIXME this can go, it will be handled by insertPost
-    if (range.head.section.isCardSection) {
-      return;
-    }
     if (!range.isCollapsed) {
       editor.handleDeletion();
     }

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -5,6 +5,7 @@ import Set from 'mobiledoc-kit/utils/set';
 import mobiledocRenderers from 'mobiledoc-kit/renderers/mobiledoc';
 import Range from 'mobiledoc-kit/utils/cursor/range';
 import Position from 'mobiledoc-kit/utils/cursor/position';
+import deprecate from 'mobiledoc-kit/utils/deprecate';
 
 export default class Post {
   constructor() {
@@ -223,10 +224,18 @@ export default class Post {
   }
 
   /**
-   * @param {Range} range
-   * @return {Mobiledoc} A mobiledoc representation of the range (JSON)
+   * @deprecated
    */
   cloneRange(range) {
+    deprecate('post#cloneRange is deprecated. See post#trimTo(range) and editor#serializePost');
+    return mobiledocRenderers.render(this.trimTo(range));
+  }
+
+  /**
+   * @param {Range} range
+   * @return {Post} A new post, constrained to {range}
+   */
+  trimTo(range) {
     const post = this.builder.createPost();
     const { builder } = this;
 
@@ -263,6 +272,6 @@ export default class Post {
         sectionParent.sections.append(newSection);
       }
     });
-    return mobiledocRenderers.render(post);
+    return post;
   }
 }

--- a/src/js/utils/deprecate.js
+++ b/src/js/utils/deprecate.js
@@ -1,0 +1,3 @@
+export default function deprecate(message) {
+  console.log(`DEPRECATED: ${message}`); // jshint ignore:line
+}

--- a/src/js/utils/parse-utils.js
+++ b/src/js/utils/parse-utils.js
@@ -2,8 +2,6 @@
 import mobiledocParsers from '../parsers/mobiledoc';
 import HTMLParser from '../parsers/html';
 import TextParser from '../parsers/text';
-import HTMLRenderer from 'mobiledoc-html-renderer';
-import TextRenderer from 'mobiledoc-text-renderer';
 import Logger from 'mobiledoc-kit/utils/logger';
 
 export const MIME_TEXT_PLAIN = 'text/plain';
@@ -13,6 +11,9 @@ export const NONSTANDARD_IE_TEXT_TYPE = 'Text';
 const log = Logger.for('parse-utils');
 const MOBILEDOC_REGEX = new RegExp(/data\-mobiledoc='(.*?)'>/);
 
+/**
+ * @return {Post}
+ */
 function parsePostFromHTML(html, builder, plugins) {
   let post;
 
@@ -27,36 +28,26 @@ function parsePostFromHTML(html, builder, plugins) {
   return post;
 }
 
+/**
+ * @return {Post}
+ */
 function parsePostFromText(text, builder, plugins) {
   let parser = new TextParser(builder, {plugins});
   let post = parser.parse(text);
   return post;
 }
 
-// Sets the clipboard data in a cross-browser way.
-function setClipboardData(clipboardData, html, plain) {
-  if (clipboardData && clipboardData.setData) {
-    clipboardData.setData(MIME_TEXT_HTML, html);
-    clipboardData.setData(MIME_TEXT_PLAIN, plain);
-  } else if (window.clipboardData && window.clipboardData.setData) { // IE
-    // The Internet Explorers (including Edge) have a non-standard way of interacting with the
-    // Clipboard API (see http://caniuse.com/#feat=clipboard). In short, they expose a global window.clipboardData
-    // object instead of the per-event event.clipboardData object on the other browsers.
-    window.clipboardData.setData(NONSTANDARD_IE_TEXT_TYPE, html);
-  }
-}
+/**
+ * @return {{html: String, text: String}}
+ */
+export function getContentFromPasteEvent(event, window) {
+  let html = '', text = '';
 
-// Gets the clipboard data in a cross-browser way.
-function getClipboardData(clipboardData) {
-  let html;
-  let text;
+  let { clipboardData } = event;
 
   if (clipboardData && clipboardData.getData) {
     html = clipboardData.getData(MIME_TEXT_HTML);
-
-    if (!html || html.length === 0) { // Fallback to 'text/plain'
-      text = clipboardData.getData(MIME_TEXT_PLAIN);
-    }
+    text = clipboardData.getData(MIME_TEXT_PLAIN);
   } else if (window.clipboardData && window.clipboardData.getData) { // IE
     // The Internet Explorers (including Edge) have a non-standard way of interacting with the
     // Clipboard API (see http://caniuse.com/#feat=clipboard). In short, they expose a global window.clipboardData
@@ -68,67 +59,74 @@ function getClipboardData(clipboardData) {
 }
 
 /**
- * @param {Event} copyEvent
- * @param {Editor}
- * @return null
+ * @return {{html: String, text: String}}
  */
-export function setClipboardCopyData(copyEvent, editor) {
-  const { range, post } = editor;
+function getContentFromDropEvent(event) {
+  let html = '', text = '';
 
-  const mobiledoc = post.cloneRange(range);
-
-  const unknownCardHandler = () => {}; // ignore unknown cards
-  const unknownAtomHandler = () => {}; // ignore unknown atoms
-  const {result: innerHTML} =
-    new HTMLRenderer({unknownCardHandler, unknownAtomHandler}).render(mobiledoc);
-
-  const html =
-    `<div data-mobiledoc='${JSON.stringify(mobiledoc)}'>${innerHTML}</div>`;
-  const {result: plain} =
-    new TextRenderer({unknownCardHandler, unknownAtomHandler}).render(mobiledoc);
-
-  setClipboardData(copyEvent.clipboardData, html, plain);
-}
-
-/**
- * @param {Event} pasteEvent
- * @param {PostNodeBuilder} builder
- * @param {Array} plugins parser plugins
- * @return {Post}
- */
-export function parsePostFromPaste(pasteEvent, {builder, _parserPlugins: plugins}) {
-  let post;
-
-  const { html, text } = getClipboardData(pasteEvent.clipboardData);
-  if (html && html.length > 0) {
-    post = parsePostFromHTML(html, builder, plugins);
-  } else if (text && text.length > 0) {
-    post = parsePostFromText(text, builder, plugins);
-  }
-
-  return post;
-}
-
-export function parsePostFromDrop(dropEvent, {builder, _parserPlugins: plugins}) {
-  let post;
-
-  let html, text;
   try {
-    html = dropEvent.dataTransfer.getData('text/html');
-    text = dropEvent.dataTransfer.getData('text/plain');
+    html = event.dataTransfer.getData(MIME_TEXT_HTML);
+    text = event.dataTransfer.getData(MIME_TEXT_PLAIN);
   } catch (e) {
     // FIXME IE11 does not include any data in the 'text/html' or 'text/plain'
     // mimetypes. It throws an error 'Invalid argument' when attempting to read
     // these properties.
     log('Error getting drop data: ', e);
-    return;
   }
 
-  if (html && html.length > 0) {
-    post = parsePostFromHTML(html, builder, plugins);
-  } else if (text && text.length > 0) {
-    post = parsePostFromText(text, builder, plugins);
+  return { html, text };
+}
+
+/**
+ * @param {CopyEvent|CutEvent}
+ * @param {Editor}
+ * @param {Window}
+ */
+export function setClipboardData(event, {mobiledoc, html, text}, window) {
+  if (mobiledoc && html) {
+    html = `<div data-mobiledoc='${JSON.stringify(mobiledoc)}'>${html}</div>`;
   }
 
-  return post;
+  let { clipboardData } = event;
+  let { clipboardData: nonstandardClipboardData } = window;
+
+  if (clipboardData && clipboardData.setData) {
+    clipboardData.setData(MIME_TEXT_HTML, html);
+    clipboardData.setData(MIME_TEXT_PLAIN, text);
+  } else if (nonstandardClipboardData && nonstandardClipboardData.setData) {
+    // The Internet Explorers (including Edge) have a non-standard way of interacting with the
+    // Clipboard API (see http://caniuse.com/#feat=clipboard). In short, they expose a global window.clipboardData
+    // object instead of the per-event event.clipboardData object on the other browsers.
+    nonstandardClipboardData.setData(NONSTANDARD_IE_TEXT_TYPE, html);
+  }
+}
+
+/**
+ * @param {PasteEvent}
+ * @param {{builder: Builder, _parserPlugins: Array}} options
+ * @return {Post}
+ */
+export function parsePostFromPaste(pasteEvent, {builder, _parserPlugins: plugins}) {
+  let { html, text } = getContentFromPasteEvent(pasteEvent, window);
+
+  if (html && html.length) {
+    return parsePostFromHTML(html, builder, plugins);
+  } else if (text && text.length) {
+    return parsePostFromText(text, builder, plugins);
+  }
+}
+
+/**
+ * @param {DropEvent}
+ * @param {{builder: Builder, _parserPlugins: Array}} options
+ * @return {Post}
+ */
+export function parsePostFromDrop(dropEvent, {builder, _parserPlugins: plugins}) {
+  let { html, text } = getContentFromDropEvent(dropEvent);
+
+  if (html && html.length) {
+    return parsePostFromHTML(html, builder, plugins);
+  } else if (text && text.length) {
+    return parsePostFromText(text, builder, plugins);
+  }
 }

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -1,13 +1,12 @@
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
 import Range from 'mobiledoc-kit/utils/cursor/range';
-import { supportsStandardClipboardAPI } from '../helpers/browsers';
 import {
   MIME_TEXT_PLAIN,
   MIME_TEXT_HTML
 } from 'mobiledoc-kit/utils/parse-utils';
 
-const { module, skipInIE11 } = Helpers;
+const { module, test } = Helpers;
 
 const cards = [{
   name: 'my-card',
@@ -31,9 +30,9 @@ module('Acceptance: editor: copy-paste', {
   }
 });
 
-// These tests do not work in Sauce Labs on IE11 because access to the clipboard must be manually allowed.
-// TODO: Configure IE11 to automatically allow access to the clipboard.
-skipInIE11('simple copy-paste at end of section works', (assert) => {
+// TODO: Modify these tests to use IE's nonstandard clipboard access pattern
+// See: https://remysharp.com/2015/10/14/the-art-of-debugging
+test('simple copy-paste at end of section works', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
@@ -53,7 +52,7 @@ skipInIE11('simple copy-paste at end of section works', (assert) => {
   assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
 });
 
-skipInIE11('paste plain text', (assert) => {
+test('paste plain text', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
@@ -71,7 +70,7 @@ skipInIE11('paste plain text', (assert) => {
   assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
 });
 
-skipInIE11('paste plain text with line breaks', (assert) => {
+test('paste plain text with line breaks', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
@@ -86,17 +85,12 @@ skipInIE11('paste plain text with line breaks', (assert) => {
   Helpers.dom.setCopyData(MIME_TEXT_PLAIN, ['abc', 'def'].join('\n'));
   Helpers.dom.triggerPasteEvent(editor);
 
-  if (supportsStandardClipboardAPI()) {
-    assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
-    assert.hasElement('#editor p:contains(def)', 'second section is pasted');
-    assert.equal($('#editor p').length, 2, 'adds a second section');
-  } else {
-    assert.hasElement('#editor p:contains(abcabc\ndef)', 'pastes the text');
-    assert.equal($('#editor p').length, 1, 'adds a second section');
-  }
+  assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
+  assert.hasElement('#editor p:contains(def)', 'second section is pasted');
+  assert.equal($('#editor p').length, 2, 'adds a second section');
 });
 
-skipInIE11('paste plain text with list items', (assert) => {
+test('paste plain text with list items', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
@@ -111,15 +105,11 @@ skipInIE11('paste plain text with list items', (assert) => {
   Helpers.dom.setCopyData(MIME_TEXT_PLAIN, ['* abc', '* def'].join('\n'));
   Helpers.dom.triggerPasteEvent(editor);
 
-  if (supportsStandardClipboardAPI()) {
-    assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
-    assert.hasElement('#editor ul li:contains(def)', 'list item is pasted');
-  } else {
-    assert.hasElement('#editor p:contains(abc* abc\n* def)', 'pastes the text');
-  }
+  assert.hasElement('#editor p:contains(abcabc)', 'pastes the text');
+  assert.hasElement('#editor ul li:contains(def)', 'list item is pasted');
 });
 
-skipInIE11('can cut and then paste content', (assert) => {
+test('can cut and then paste content', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
@@ -143,7 +133,7 @@ skipInIE11('can cut and then paste content', (assert) => {
   assert.hasElement('#editor p:contains(abc)', 'pastes the text');
 });
 
-skipInIE11('paste when text is selected replaces that text', (assert) => {
+test('paste when text is selected replaces that text', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
@@ -164,7 +154,7 @@ skipInIE11('paste when text is selected replaces that text', (assert) => {
                     'pastes, replacing the selection');
 });
 
-skipInIE11('simple copy-paste with markup at end of section works', (assert) => {
+test('simple copy-paste with markup at end of section works', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker, markup}) => {
     return post([markupSection('p', [
@@ -188,7 +178,7 @@ skipInIE11('simple copy-paste with markup at end of section works', (assert) => 
   assert.equal($('#editor p strong:contains(a)').length, 2, 'two bold As');
 });
 
-skipInIE11('simple copy-paste in middle of section works', (assert) => {
+test('simple copy-paste in middle of section works', (assert) => {
    const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abcd')])]);
   });
@@ -209,7 +199,7 @@ skipInIE11('simple copy-paste in middle of section works', (assert) => {
   assert.hasElement('#editor p:contains(acXbcd)', 'inserts text in right spot');
 });
 
-skipInIE11('simple copy-paste at start of section works', (assert) => {
+test('simple copy-paste at start of section works', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abcd')])]);
   });
@@ -230,7 +220,7 @@ skipInIE11('simple copy-paste at start of section works', (assert) => {
   assert.hasElement('#editor p:contains(cXabcd)', 'inserts text in right spot');
 });
 
-skipInIE11('copy-paste can copy cards', (assert) => {
+test('copy-paste can copy cards', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker, cardSection}) => {
     return post([
@@ -267,7 +257,7 @@ skipInIE11('copy-paste can copy cards', (assert) => {
   assert.equal($('#editor .bar').length, 2, 'renders a second card');
 });
 
-skipInIE11('copy-paste can copy list sections', (assert) => {
+test('copy-paste can copy list sections', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker, listSection, listItem}) => {
     return post([
@@ -295,7 +285,7 @@ skipInIE11('copy-paste can copy list sections', (assert) => {
   assert.hasElement($('#editor ul:eq(0) li:contains(list)'));
 });
 
-skipInIE11('copy sets html & text for pasting externally', (assert) => {
+test('copy sets html & text for pasting externally', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => {
       return post([
@@ -313,56 +303,52 @@ skipInIE11('copy sets html & text for pasting externally', (assert) => {
   Helpers.dom.triggerCopyEvent(editor);
 
   let html = Helpers.dom.getCopyData(MIME_TEXT_HTML);
-  if (supportsStandardClipboardAPI()) {
-    let text = Helpers.dom.getCopyData(MIME_TEXT_PLAIN);
-    assert.equal(text, ["heading", "h2 subheader", "The text" ].join('\n'),
-                 'gets plain text');
-  }
+  let text = Helpers.dom.getCopyData(MIME_TEXT_PLAIN);
+  assert.equal(text, ["heading", "h2 subheader", "The text" ].join('\n'),
+               'gets plain text');
 
   assert.ok(html.indexOf("<h1>heading") !== -1, 'html has h1');
   assert.ok(html.indexOf("<h2>h2 subheader") !== -1, 'html has h2');
   assert.ok(html.indexOf("<p>The text") !== -1, 'html has p');
 });
 
-skipInIE11('pasting when on the end of a card is blocked', (assert) => {
-  const mobiledoc = Helpers.mobiledoc.build(
-    ({post, cardSection, markupSection, marker}) => {
-    return post([
-      cardSection('my-card'),
-      markupSection('p', [marker('abc')])
+test('pasting when cursor is on left/right side of card adds content before/after card', (assert) => {
+  let expected1, expected2;
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, cardSection, marker}) => {
+    expected1 = post([
+      markupSection('p', [marker('abc')]),
+      cardSection('my-card')
     ]);
-  });
-  editor = new Editor({mobiledoc, cards});
-  editor.render(editorElement);
 
-  Helpers.dom.selectText(editor, 'abc', editorElement);
-  Helpers.dom.triggerCopyEvent(editor);
+    expected2 = post([
+      markupSection('p', [marker('abc')]),
+      cardSection('my-card'),
+      markupSection('p', [marker('123')])
+    ]);
 
-  editor.selectRange(new Range(editor.post.sections.head.headPosition()));
+    return post([
+      cardSection('my-card')
+    ]);
+  }, {cards});
+
+  let card = editor.post.sections.objectAt(0);
+  assert.ok(card.isCardSection, 'precond - get card');
+
+  Helpers.dom.setCopyData(MIME_TEXT_PLAIN, 'abc');
+  editor.selectRange(new Range(card.headPosition()));
   Helpers.dom.triggerPasteEvent(editor);
 
-  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
-    ({post, cardSection, markupSection, marker}) => {
-      return post([
-        cardSection('my-card'),
-        markupSection('p', [marker('abc')])
-      ]);
-    }), 'no paste has occurred');
+  assert.postIsSimilar(editor.post, expected1, 'content pasted before card');
 
-  editor.selectRange(new Range(editor.post.sections.head.tailPosition()));
+  Helpers.dom.setCopyData(MIME_TEXT_PLAIN, '123');
+  editor.selectRange(new Range(card.tailPosition()));
   Helpers.dom.triggerPasteEvent(editor);
 
-  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
-    ({post, cardSection, markupSection, marker}) => {
-      return post([
-        cardSection('my-card'),
-        markupSection('p', [marker('abc')])
-      ]);
-    }), 'no paste has occurred');
+  assert.postIsSimilar(editor.post, expected2, 'content pasted after card');
 });
 
 // see https://github.com/bustlelabs/mobiledoc-kit/issues/249
-skipInIE11('pasting when replacing a list item works', (assert) => {
+test('pasting when replacing a list item works', (assert) => {
   let mobiledoc = Helpers.mobiledoc.build(
     ({post, listSection, listItem, markupSection, marker}) => {
     return post([

--- a/tests/helpers/browsers.js
+++ b/tests/helpers/browsers.js
@@ -11,9 +11,3 @@ export function supportsSelectionExtend() {
   let selection = window.getSelection();
   return !!selection.extend;
 }
-
-// See http://caniuse.com/#feat=clipboard
-// This rules out the Internet Explorers.
-export function supportsStandardClipboardAPI() {
-  return !window.clipboardData;
-}

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -4,12 +4,10 @@ import KEY_CODES from 'mobiledoc-kit/utils/keycodes';
 import { DIRECTION, MODIFIERS }  from 'mobiledoc-kit/utils/key';
 import { isTextNode } from 'mobiledoc-kit/utils/dom-utils';
 import { merge } from 'mobiledoc-kit/utils/merge';
-import { supportsStandardClipboardAPI } from './browsers';
 import { Editor } from 'mobiledoc-kit';
 import {
   MIME_TEXT_PLAIN,
-  MIME_TEXT_HTML,
-  NONSTANDARD_IE_TEXT_TYPE
+  MIME_TEXT_HTML
 } from 'mobiledoc-kit/utils/parse-utils';
 
 // walks DOWN the dom from node to childNodes, returning the element
@@ -277,15 +275,13 @@ function triggerLeftArrowKey(editor, modifier) {
 // Allows our fake copy and paste events to communicate with each other.
 const lastCopyData = {};
 function triggerCopyEvent(editor) {
-  let eventData = {};
-
-  if (supportsStandardClipboardAPI()) {
-    eventData = {
-      clipboardData: {
-        setData(type, value) { lastCopyData[type] = value; }
+  let eventData = {
+    clipboardData: {
+      setData(type, value) {
+        lastCopyData[type] = value;
       }
-    };
-  }
+    }
+  };
 
   let event = createMockEvent('copy', editor.element, eventData);
   _triggerEditorEvent(editor, event);
@@ -301,15 +297,11 @@ function triggerCutEvent(editor) {
 }
 
 function triggerPasteEvent(editor) {
-  let eventData = {};
-
-  if (supportsStandardClipboardAPI()) {
-    eventData = {
-      clipboardData: {
-        getData(type) { return lastCopyData[type]; }
-      }
-    };
-  }
+  let eventData = {
+    clipboardData: {
+      getData(type) { return lastCopyData[type]; }
+    }
+  };
 
   let event = createMockEvent('paste', editor.element, eventData);
   _triggerEditorEvent(editor, event);
@@ -338,19 +330,11 @@ function triggerDropEvent(editor, {html, text, clientX, clientY}) {
 }
 
 function getCopyData(type) {
-  if (supportsStandardClipboardAPI()) {
-    return lastCopyData[type];
-  } else {
-    return window.clipboardData.getData(NONSTANDARD_IE_TEXT_TYPE);
-  }
+  return lastCopyData[type];
 }
 
 function setCopyData(type, value) {
-  if (supportsStandardClipboardAPI()) {
-    lastCopyData[type] = value;
-  } else {
-    window.clipboardData.setData(NONSTANDARD_IE_TEXT_TYPE, value);
-  }
+  lastCopyData[type] = value;
 }
 
 function clearCopyData() {

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -447,29 +447,28 @@ test('#sectionsContainedBy when range starts/ends in list item', (assert) => {
   assert.ok(containedSections.indexOf(s1) !== -1, 'contains section');
 });
 
-test('#cloneRange creates a mobiledoc from the given range', (assert) => {
-  const post = Helpers.postAbstract.build(
+test('#trimTo creates a post from the given range', (assert) => {
+  let post = Helpers.postAbstract.build(
     ({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abc')])]);
   });
   const section = post.sections.head;
   const range = Range.create(section,1,section,2); // "b"
 
-  const mobiledoc = post.cloneRange(range);
-  const expectedMobiledoc = Helpers.mobiledoc.build(({post, marker, markupSection}) => {
+  post = post.trimTo(range);
+  let expected = Helpers.postAbstract.build(({post, marker, markupSection}) => {
     return post([markupSection('p',[marker('b')])]);
   });
 
-  assert.deepEqual(mobiledoc, expectedMobiledoc);
+  assert.postIsSimilar(post, expected);
 });
 
-test('#cloneRange copies card sections', (assert) => {
+test('#trimTo copies card sections', (assert) => {
   let cardPayload = {foo: 'bar'};
 
-  let buildPost = Helpers.postAbstract.build,
-      buildMobiledoc = Helpers.mobiledoc.build;
+  let buildPost = Helpers.postAbstract.build;
 
-  const post = buildPost(
+  let post = buildPost(
     ({post, markupSection, marker, cardSection}) => {
     return post([
       markupSection('p', [marker('abc')]),
@@ -481,8 +480,8 @@ test('#cloneRange copies card sections', (assert) => {
   const range = Range.create(post.sections.head, 1,  // 'b'
                              post.sections.tail, 1); // '2'
 
-  const mobiledoc = post.cloneRange(range);
-  const expectedMobiledoc = buildMobiledoc(
+  post = post.trimTo(range);
+  let expected = buildPost(
     ({post, marker, markupSection, cardSection}) => {
     return post([
       markupSection('p',[marker('bc')]),
@@ -491,12 +490,11 @@ test('#cloneRange copies card sections', (assert) => {
     ]);
   });
 
-  assert.deepEqual(mobiledoc, expectedMobiledoc);
+  assert.postIsSimilar(post, expected);
 });
 
-test('#cloneRange when range starts and ends in a list item', (assert) => {
-  let buildPost = Helpers.postAbstract.build,
-      buildMobiledoc = Helpers.mobiledoc.build;
+test('#trimTo when range starts and ends in a list item', (assert) => {
+  let buildPost = Helpers.postAbstract.build;
 
   let post = buildPost(
     ({post, listSection, listItem, marker}) => {
@@ -506,18 +504,17 @@ test('#cloneRange when range starts and ends in a list item', (assert) => {
   let range = Range.create(post.sections.head.items.head, 0,
                            post.sections.head.items.head, 'ab'.length);
 
-  let mobiledoc = post.cloneRange(range);
-  let expected = buildMobiledoc(
+  post = post.trimTo(range);
+  let expected = buildPost(
     ({post, listSection, listItem, marker}) => {
     return post([listSection('ul', [listItem([marker('ab')])])]);
   });
 
-  assert.deepEqual(mobiledoc, expected);
+  assert.postIsSimilar(post, expected);
 });
 
-test('#cloneRange when range contains multiple list items', (assert) => {
-  let buildPost = Helpers.postAbstract.build,
-      buildMobiledoc = Helpers.mobiledoc.build;
+test('#trimTo when range contains multiple list items', (assert) => {
+  let buildPost = Helpers.postAbstract.build;
 
   let post = buildPost(
     ({post, listSection, listItem, marker}) => {
@@ -531,8 +528,8 @@ test('#cloneRange when range contains multiple list items', (assert) => {
   let range = Range.create(post.sections.head.items.head, 'ab'.length,
                            post.sections.head.items.tail, 'gh'.length);
 
-  let mobiledoc = post.cloneRange(range);
-  let expected = buildMobiledoc(
+  post = post.trimTo(range);
+  let expected = buildPost(
     ({post, listSection, listItem, marker}) => {
     return post([listSection('ul', [
       listItem([marker('c')]),
@@ -541,12 +538,11 @@ test('#cloneRange when range contains multiple list items', (assert) => {
     ])]);
   });
 
-  assert.deepEqual(mobiledoc, expected);
+  assert.postIsSimilar(post, expected);
 });
 
-test('#cloneRange when range contains multiple list items and more sections', (assert) => {
-  let buildPost = Helpers.postAbstract.build,
-      buildMobiledoc = Helpers.mobiledoc.build;
+test('#trimTo when range contains multiple list items and more sections', (assert) => {
+  let buildPost = Helpers.postAbstract.build;
 
   let post = buildPost(
     ({post, listSection, listItem, markupSection, marker}) => {
@@ -562,8 +558,8 @@ test('#cloneRange when range contains multiple list items and more sections', (a
   let range = Range.create(post.sections.head.items.head, 'ab'.length,
                            post.sections.tail, '12'.length);
 
-  let mobiledoc = post.cloneRange(range);
-  let expected = buildMobiledoc(
+  post = post.trimTo(range);
+  let expected = buildPost(
     ({post, listSection, listItem, markupSection, marker}) => {
     return post([listSection('ul', [
       listItem([marker('c')]),
@@ -574,7 +570,7 @@ test('#cloneRange when range contains multiple list items and more sections', (a
     ])]);
   });
 
-  assert.deepEqual(mobiledoc, expected);
+  assert.postIsSimilar(post, expected);
 });
 
 test('#headPosition and #tailPosition returns head and tail', (assert) => {

--- a/tests/unit/utils/parse-utils-test.js
+++ b/tests/unit/utils/parse-utils-test.js
@@ -1,0 +1,115 @@
+import Helpers from '../../test-helpers';
+import {
+  MIME_TEXT_PLAIN,
+  MIME_TEXT_HTML,
+  NONSTANDARD_IE_TEXT_TYPE,
+  getContentFromPasteEvent,
+  setClipboardData
+} from 'mobiledoc-kit/utils/parse-utils';
+
+const {module, test} = Helpers;
+
+module('Unit: Utils: Parse Utils');
+
+test('#getContentFromPasteEvent reads from clipboardData', (assert) => {
+  let element = null;
+  let expected = {
+    [MIME_TEXT_PLAIN]: 'text',
+    [MIME_TEXT_HTML]: '<p>html</p>'
+  };
+  let event = Helpers.dom.createMockEvent('paste', element, {
+    clipboardData: {
+      getData(type) {
+        return expected[type];
+      }
+    }
+  });
+  let mockWindow = {
+    clipboardData: {
+      getData() {
+        assert.ok(false, 'should not get clipboard data from window');
+      }
+    }
+  };
+
+  let { html, text } = getContentFromPasteEvent(event, mockWindow);
+
+  assert.equal(html, expected[MIME_TEXT_HTML], 'correct html');
+  assert.equal(text, expected[MIME_TEXT_PLAIN], 'correct text');
+});
+
+test('#getContentFromPasteEvent reads data from window.clipboardData when event.clipboardData is not present (IE compat)', (assert) => {
+  assert.expect(3);
+  let element = null;
+  let event = Helpers.dom.createMockEvent('paste', element, {clipboardData:null});
+  let requestedType;
+  let expectedHTML = 'hello';
+  let expectedText = '';
+  let mockWindow = {
+    clipboardData: {
+      getData(type) {
+        requestedType = type;
+        return expectedHTML;
+      }
+    }
+  };
+
+  let { html, text } = getContentFromPasteEvent(event, mockWindow);
+
+  assert.equal(requestedType, NONSTANDARD_IE_TEXT_TYPE, 'requests IE nonstandard mime type');
+  assert.equal(html, expectedHTML, 'correct html');
+  assert.equal(text, expectedText, 'correct text');
+});
+
+test('#setClipboardData uses event.clipboardData.setData when available', (assert) => {
+  let element = null;
+  let setData = {};
+  let data = {
+    html: '<p>html</p>',
+    text: 'text'
+  };
+  let event = Helpers.dom.createMockEvent('copy', element, {
+    clipboardData: {
+      setData(type, value) {
+        setData[type] = value;
+      }
+    }
+  });
+  let mockWindow = {
+    clipboardData: {
+      setData() {
+        assert.ok(false, 'should not set clipboard data on window');
+      }
+    }
+  };
+
+  setClipboardData(event, data, mockWindow);
+
+  assert.equal(setData[MIME_TEXT_HTML], data.html);
+  assert.equal(setData[MIME_TEXT_PLAIN], data.text);
+});
+
+test('#setClipboardData uses window.clipboardData.setData when event.clipboardData not present (IE compat)', (assert) => {
+  let element = null;
+  let setData = {};
+  let data = {
+    html: '<p>html</p>',
+    text: 'text'
+  };
+  let event = Helpers.dom.createMockEvent('paste', element, {
+    clipboardData: null
+  });
+  let mockWindow = {
+    clipboardData: {
+      setData(type, value) {
+        setData[type] = value;
+      }
+    }
+  };
+
+  setClipboardData(event, data, mockWindow);
+
+  assert.equal(setData[NONSTANDARD_IE_TEXT_TYPE], data.html, 'sets NONSTANDARD_IE_TEXT_TYPE type');
+  assert.ok(!setData[MIME_TEXT_HTML], 'does not set MIME_TEXT_HTML');
+  assert.ok(!setData[MIME_TEXT_PLAIN], 'does not set MIME_TEXT_PLAIN');
+});

--- a/tests/unit/utils/selection-utils-test.js
+++ b/tests/unit/utils/selection-utils-test.js
@@ -1,4 +1,5 @@
-const {module, test} = QUnit;
+import Helpers from '../../test-helpers';
+const {module, test} = Helpers;
 
 import { comparePosition } from 'mobiledoc-kit/utils/selection-utils';
 import { DIRECTION } from 'mobiledoc-kit/utils/key';


### PR DESCRIPTION
  * Add `editor#serializeTo(format)`
  * Add `editor#serializePost(post, format)`
  * Add deprecate helper
  * Add `post#trimTo(range)` and deprecate `post#cloneRange`.
   `cloneRange` returns a mobiledoc, which is confusing.
  * Enable all copy-paste acceptance tests in IE. They all now use
    the copy/paste mocks from the test helpers.
  * Add an IE-compatibility test for `getContentFromPasteEvent` to
    ensure it will use `window.clipboardData`
  * Add an IE-compatibility test for `setClipboardData` to
    ensure it will use `window.clipboardData`
  * Remove now-unused `supportsStandardClipboardAPI` test helper

cc @YoranBrondsema this turns on all tests in all environments. Adds IE-compatibility tests for the two methods that may interact directly with `window.clipboardData`.