### PR TITLE
[BUGFIX] up/down arrows in Firefox should not update mobiledoc

### DIFF
--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -159,10 +159,6 @@ const Key = class Key {
     return MODIFIERS.ALT & this.modifierMask;
   }
 
-  isChar(string) {
-    return this.keyCode === string.toUpperCase().charCodeAt(0);
-  }
-
   /**
    * See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#Printable_keys_in_standard_position
    *   and http://stackoverflow.com/a/12467610/137784
@@ -172,13 +168,16 @@ const Key = class Key {
       return false;
     }
 
-    if (this.toString().length) {
-      return true;
-    }
-
     const {keyCode:code} = this;
 
+    // Firefox calls keypress events for arrow keys, but they should not be
+    // considered printable
+    if (this.isArrow()) {
+      return false;
+    }
+
     return (
+      this.toString().length > 0 ||
       (code >= Keycodes['0'] && code <= Keycodes['9']) ||         // number keys
       this.isSpace() ||
       this.isTab()   ||

--- a/tests/unit/utils/key-test.js
+++ b/tests/unit/utils/key-test.js
@@ -1,6 +1,7 @@
 import Helpers from '../../test-helpers';
 import Key from 'mobiledoc-kit/utils/key';
 import { MODIFIERS } from 'mobiledoc-kit/utils/key';
+import Keycodes from 'mobiledoc-kit/utils/keycodes';
 
 const {module, test} = Helpers;
 
@@ -36,4 +37,16 @@ test('#hasModifier with SHIFT', (assert) => {
   assert.ok(!key.hasModifier(MODIFIERS.META), "META not pressed");
   assert.ok(!key.hasModifier(MODIFIERS.CTRL), "CTRL not pressed");
   assert.ok(key.hasModifier(MODIFIERS.SHIFT), "SHIFT pressed");
+});
+
+// Firefox will fire keypress events for up/down arrow keys,
+// they should not be considered printable
+test('firefox arrow keypress is not printable', (assert) => {
+  let element = $('#qunit-fixture')[0];
+  let event = Helpers.dom.createMockEvent('keypress', element, {
+    keyCode: Keycodes.DOWN,
+    charCode: 0
+  });
+  let key = Key.fromEvent(event);
+  assert.ok(!key.isPrintable());
 });


### PR DESCRIPTION
Firefox fires `keypress` events for up/down arrows (Chrome, Safari and IE11 do not), and `Key#isPrintable` was incorrectly returning true for these events because `String.fromCharCode(0).length > 0`. This updates `Key#isPrintable` to return false when the source event was an arrow keypress.