### PR TITLE
[CLEANUP] Fix jsdoc formatting, add `docs` npm script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ keys.txt
 export.sh
 dist/
 tmp/
+docs/
 
 server.sh

--- a/.jsdoc
+++ b/.jsdoc
@@ -1,0 +1,13 @@
+{
+  "source": {
+    "include": ["./src/js"]
+  },
+  "opts": {
+    "readme": "./README.md",
+    "recurse": true,
+    "destination": "./docs"
+  },
+  "plugins": [
+    "plugins/markdown"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "rm -rf dist && broccoli build dist",
     "build-website": "./bin/build-website.sh",
     "deploy-website": "./bin/deploy-website.sh",
-    "update-changelog": "./node_modules/conventional-changelog-cli/cli.js -i CHANGELOG.md -r 0 -s && git add CHANGELOG.md && git commit -m 'Update changelog'"
+    "update-changelog": "conventional-changelog -i CHANGELOG.md -r 0 -s && git add CHANGELOG.md && git commit -m 'Update changelog'",
+    "docs": "jsdoc -c ./.jsdoc"
   },
   "keywords": [
     "html",
@@ -47,6 +48,7 @@
     "conventional-changelog": "^1.1.0",
     "conventional-changelog-cli": "^1.1.1",
     "jquery": "^2.2.2",
+    "jsdoc": "^3.4.0",
     "saucie": "^1.4.0",
     "testem": "^1.6.0"
   },

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -19,6 +19,21 @@ const CALLBACK_QUEUES = {
 };
 
 class PostEditor {
+  /**
+   * The PostEditor is used to modify a post. It should not be instantiated directly.
+   * Instead, a new instance of a PostEditor is created by the editor and passed
+   * as the argument to the callback in {@link Editor#run}.
+   *
+   * Usage:
+   * ```
+   * editor.run((postEditor) => {
+   *   // postEditor is an instance of PostEditor that can operate on the
+   *   // editor's post
+   * });
+   * ```
+   * @param {Editor} editor
+   * @class PostEditor
+   */
   constructor(editor) {
     this.editor = editor;
     this.builder = this.editor.builder;
@@ -43,16 +58,15 @@ class PostEditor {
   }
 
   /**
-   * Remove a range from the post
+   * Delete a range from the post
    *
    * Usage:
-   *
+   * ```
    *     let { range } = editor;
    *     editor.run((postEditor) => {
    *       postEditor.deleteRange(range);
    *     });
-   *
-   * @method deleteRange
+   * ```
    * @param {Range} range Cursor Range object with head and tail Positions
    * @return {Position} The position where the cursor would go after deletion
    * @public
@@ -132,6 +146,7 @@ class PostEditor {
 
   /**
    * @return {Position}
+   * @private
    */
   cutSection(section, headSectionOffset, tailSectionOffset) {
     if (section.isBlank || headSectionOffset === tailSectionOffset) {
@@ -343,7 +358,6 @@ class PostEditor {
    * or direction is `FORWARD` and the offset is equal to the length of the
    * marker.
    *
-   * @method deleteFrom
    * @param {Position} position object with {section, offset} the marker and offset to delete from
    * @param {Number} direction The direction to delete in (default is BACKWARD)
    * @return {Position} for positioning the cursor
@@ -393,7 +407,6 @@ class PostEditor {
 
   /**
    * delete 1 character in the FORWARD direction from the given position
-   * @method _deleteForwardFrom
    * @param {Position} position
    * @private
    */
@@ -448,8 +461,9 @@ class PostEditor {
   /**
    * delete 1 character forward from the markerPosition
    *
-   * @method _deleteForwardFromMarkerPosition
-   * @param {Object} markerPosition {marker, offset}
+   * @param {Object} markerPosition
+   * @param {Marker} markerPosition.marker
+   * @param {number} markerPosition.offset
    * @return {Position} The position the cursor should be put after this deletion
    * @private
    */
@@ -487,7 +501,6 @@ class PostEditor {
 
   /**
    * delete 1 character in the BACKWARD direction from the given position
-   * @method _deleteBackwardFrom
    * @param {Position} position
    * @return {Position} The position the cursor should be put after this deletion
    * @private
@@ -534,16 +547,15 @@ class PostEditor {
    * (e.g. `editor.range`) as an argument.
    *
    * Usage:
-   *
+   * ```
    *     let markerRange = this.cursor.offsets;
    *     editor.run((postEditor) => {
    *       postEditor.splitMarkers(markerRange);
    *     });
-   *
+   * ```
    * The return value will be marker object completely inside the offsets
    * provided. Markers on the outside of the split may also have been modified.
    *
-   * @method splitMarkers
    * @param {Range} markerRange
    * @return {Array} of markers that are inside the split
    * @private
@@ -590,19 +602,18 @@ class PostEditor {
    * Split the section at the position.
    *
    * Usage:
-   *
+   * ```
    *     let position = editor.cursor.offsets.head;
    *     editor.run((postEditor) => {
    *       postEditor.splitSection(position);
    *     });
    *     // Will result in the creation of two new sections
    *     // replacing the old one at the cursor position
-   *
+   * ```
    * The return value will be the two new sections. One or both of these
    * sections can be blank (contain only a blank marker), for example if the
    * headMarkerOffset is 0.
    *
-   * @method splitSection
    * @param {Position} position
    * @return {Array} new sections, one for the first half and one for the second
    * @public
@@ -637,10 +648,9 @@ class PostEditor {
   }
 
   /**
-   * @method _splitCardSection
    * @param {Section} cardSection
    * @param {Position} position to split at
-   * @return {Array} pre and post-split sections
+   * @return {Section[]} 2-item array of pre and post-split sections
    * @private
    */
   _splitCardSection(cardSection, position) {
@@ -667,7 +677,6 @@ class PostEditor {
   }
 
   /**
-   * @method replaceSection
    * @param {Section} section
    * @param {Section} newSection
    * @return null
@@ -691,7 +700,6 @@ class PostEditor {
   }
 
   /**
-   * @method moveSectionUp
    * @param {Section} section A section that is already in DOM
    * @public
    */
@@ -707,7 +715,6 @@ class PostEditor {
   }
 
   /**
-   * @method moveSectionDown
    * @param {Section} section A section that is already in DOM
    * @public
    */
@@ -798,7 +805,6 @@ class PostEditor {
    * The return value will be all markers between the split, the same return
    * value as `splitMarkers`.
    *
-   * @method addMarkupToRange
    * @param {Range} range
    * @param {Markup} markup A markup post abstract node
    * @public
@@ -818,7 +824,7 @@ class PostEditor {
    * markup from all contained markers.
    *
    * Usage:
-   *
+   * ```
    *     let { range } = editor;
    *     let markup = markerRange.headMarker.markups[0];
    *     editor.run(postEditor => {
@@ -826,8 +832,7 @@ class PostEditor {
    *     });
    *     // Will result in some markers possibly being split, and the markup
    *     // being removed from all markers between the split.
-   *
-   * @method removeMarkupFromRange
+   * ```
    * @param {Range} range Object with offsets
    * @param {Markup|Function} markupOrCallback A markup post abstract node or
    * a function that returns true when passed a markup that should be removed
@@ -849,7 +854,7 @@ class PostEditor {
    * has the markup, the markup will be added to everything in the selection.
    *
    * Usage:
-   *
+   * ```
    * // Remove any 'strong' markup if it exists in the selection, otherwise
    * // make it all 'strong'
    * editor.run(postEditor => postEditor.toggleMarkup('strong'));
@@ -859,8 +864,7 @@ class PostEditor {
    *   const linkMarkup = postEditor.builder.createMarkup('a', {href: 'http://bustle.com'});
    *   postEditor.toggleMarkup(linkMarkup);
    * });
-   *
-   * @method toggleMarkup
+   * ```
    * @param {Markup|String} markupOrString Either a markup object created using
    * the builder (useful when adding a markup with attributes, like an 'a' markup),
    * or, if a string, the tag name of the markup (e.g. 'strong', 'em') to toggle.
@@ -886,15 +890,13 @@ class PostEditor {
   }
 
   /**
-   * @method toggleSection
-   *
-   * Toggles the active section or sections.
+   * Toggles the tagName of the active section or sections.
    * If every section has the tag name, they will all be reset to default sections.
    * Otherwise, every section will be changed to the requested type
    *
    * @param {String} sectionTagName A valid markup section or list section tag name (e.g. 'blockquote', 'h2', 'ul')
    * @param {Range} range The range over which to toggle. Defaults to the current editor's offsets
-   * a list section
+   *        a list section
    * @public
    */
   toggleSection(sectionTagName, range=this._range) {
@@ -952,6 +954,7 @@ class PostEditor {
    * If thse position is at the start or end of the item, the pre- or post-item
    * will contain a single empty ("") marker.
    * @return {Array} the pre-item and post-item on either side of the split
+   * @private
    */
   _splitListItem(item, position) {
     let { section, offset } = position;
@@ -981,6 +984,8 @@ class PostEditor {
    *
    * Note: Contiguous list sections will be joined in the before_complete queue
    * of the postEditor.
+   *
+   * @private
    */
   _splitListAtPosition(list, position) {
     assert('Cannot split list at position not in list',
@@ -1029,6 +1034,7 @@ class PostEditor {
    *         be a 1-item list containing `item`. `prev` and `next` will be
    *         removed in the before_complete queue if they are blank
    *         (and still attached).
+   *
    * @private
    */
   _splitListAtItem(list, item) {
@@ -1113,7 +1119,7 @@ class PostEditor {
    * and the rendered UI.
    *
    * Usage:
-   *
+   * ```
    *     let markerRange = editor.range;
    *     let sectionWithCursor = markerRange.headMarker.section;
    *     let section = editor.builder.createCardSection('my-image');
@@ -1121,12 +1127,11 @@ class PostEditor {
    *     editor.run((postEditor) => {
    *       postEditor.insertSectionBefore(collection, section, sectionWithCursor);
    *     });
-   *
-   * @method insertSectionBefore
+   * ```
    * @param {LinkedList} collection The list of sections to insert into
    * @param {Object} section The new section
    * @param {Object} beforeSection Optional The section "before" is relative to,
-   * if falsy the new section will be appended to the collection
+   *        if falsy the new section will be appended to the collection
    * @public
    */
   insertSectionBefore(collection, section, beforeSection) {
@@ -1137,7 +1142,6 @@ class PostEditor {
   /**
    * Insert the given section after the current active section, or, if no
    * section is active, at the end of the document.
-   * @method insertSection
    * @param {Section} section
    * @public
    */
@@ -1151,7 +1155,6 @@ class PostEditor {
 
   /**
    * Insert the given section at the end of the document.
-   * @method insertSectionAtEnd
    * @param {Section} section
    * @public
    */
@@ -1160,7 +1163,7 @@ class PostEditor {
   }
 
   /**
-   * @method insertPost
+   * Insert the `post` at the given position in the editor's post.
    * @param {Position} position
    * @param {Post} post
    * @private
@@ -1176,14 +1179,13 @@ class PostEditor {
    * Remove a given section from the post abstract and the rendered UI.
    *
    * Usage:
-   *
+   * ```
    *     let { range } = editor;
    *     let sectionWithCursor = range.head.section;
    *     editor.run((postEditor) => {
    *       postEditor.removeSection(sectionWithCursor);
    *     });
-   *
-   * @method removeSection
+   * ```
    * @param {Object} section The section to remove
    * @public
    */
@@ -1224,7 +1226,6 @@ class PostEditor {
   /**
    * A method for adding work the deferred queue
    *
-   * @method schedule
    * @param {Function} callback to run during completion
    * @public
    */
@@ -1237,7 +1238,6 @@ class PostEditor {
   /**
    * Add a rerender job to the queue
    *
-   * @method scheduleRerender
    * @public
    */
   scheduleRerender() {
@@ -1250,7 +1250,6 @@ class PostEditor {
   /**
    * Add a didUpdate job to the queue
    *
-   * @method scheduleDidUpdate
    * @public
    */
   scheduleDidUpdate() {
@@ -1268,7 +1267,6 @@ class PostEditor {
    * Flush any work on the queue. `editor.run` already does this. Calling this
    * method directly should not be needed outside `editor.run`.
    *
-   * @method complete
    * @private
    */
   complete() {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -7,6 +7,15 @@ import Range from 'mobiledoc-kit/utils/cursor/range';
 import Position from 'mobiledoc-kit/utils/cursor/position';
 import deprecate from 'mobiledoc-kit/utils/deprecate';
 
+/**
+ * The Post is an in-memory representation of an editor's document.
+ * An editor always has a single post. The post is organized into a list of
+ * sections. Each section may be markerable (contains "markers", aka editable
+ * text) or non-markerable (e.g., a card).
+ * When persisting a post, it must first be serialized (loss-lessly) into
+ * mobiledoc using {@link Editor#serialize}.
+ * @class Post
+ */
 export default class Post {
   constructor() {
     this.type = POST_TYPE;

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -89,10 +89,10 @@ function walkMarkerableNodes(parent, callback) {
   }
 }
 
-/**
- * Parses DOM element -> Post
- */
 export default class DOMParser {
+  /**
+   * Parses DOM element -> Post
+   */
   constructor(builder, options={}) {
     this.builder = builder;
     this.sectionParser = new SectionParser(this.builder, options);

--- a/src/js/parsers/mobiledoc/0-2.js
+++ b/src/js/parsers/mobiledoc/0-2.js
@@ -16,7 +16,6 @@ export default class MobiledocParser {
   }
 
   /**
-   * @method parse
    * @param {Mobiledoc}
    * @return {Post}
    */

--- a/src/js/parsers/mobiledoc/0-3.js
+++ b/src/js/parsers/mobiledoc/0-3.js
@@ -18,7 +18,6 @@ export default class MobiledocParser {
   }
 
   /**
-   * @method parse
    * @param {Mobiledoc}
    * @return {Post}
    */

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -44,12 +44,11 @@ const SKIPPABLE_ELEMENT_TAG_NAMES = [
   'style', 'head', 'title', 'meta'
 ].map(normalizeTagName);
 
-/**
- * parses an element into a section, ignoring any non-markup
- * elements contained within
- * @return {Array} sections
- */
 export default class SectionParser {
+  /**
+   * parses an element into a section, ignoring any non-markup
+   * elements contained within
+   */
   constructor(builder, options={}) {
     this.builder = builder;
     this.plugins = options.plugins || [];

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -119,6 +119,7 @@ function renderCard() {
 /**
  * Wrap the element in all of the opened markups
  * @return {DOMElement} the wrapped element
+ * @private
  */
 function wrapElement(element, openedMarkups) {
   let wrappedElement = element;
@@ -188,9 +189,11 @@ function getNextMarkerElement(renderNode) {
  * @param {DOMNode} element the element to attach the rendered marker to
  * @param {RenderNode} [previousRenderNode] The render node before this one, which
  *        affects the determination of where to insert this rendered marker.
- * @return {element, markupElement} The element (textNode) that has the text for
+ * @return {Object} With properties `element` and `markupElement`.
+ *         The element (textNode) that has the text for
  *         this marker, and the outermost rendered element. If the marker has no
  *         markups, element and markupElement will be the same textNode
+ * @private
  */
 function renderMarker(marker, parentElement, previousRenderNode) {
   let text = renderHTMLText(marker);

--- a/src/js/renderers/mobiledoc/0-2.js
+++ b/src/js/renderers/mobiledoc/0-2.js
@@ -111,7 +111,6 @@ const postOpcodeCompiler = {
  */
 export default {
   /**
-   * @method render
    * @param {Post}
    * @return {Mobiledoc}
    */

--- a/src/js/renderers/mobiledoc/0-3.js
+++ b/src/js/renderers/mobiledoc/0-3.js
@@ -146,7 +146,6 @@ const postOpcodeCompiler = {
  */
 export default {
   /**
-   * @method render
    * @param {Post}
    * @return {Mobiledoc}
    */

--- a/src/js/utils/array-utils.js
+++ b/src/js/utils/array-utils.js
@@ -40,6 +40,7 @@ function toArray(arrayLike) {
 /**
  * Useful for array-like things that aren't
  * actually arrays, like NodeList
+ * @private
  */
 function forEach(enumerable, callback) {
   if (enumerable.forEach) {
@@ -61,6 +62,7 @@ function filter(enumerable, conditionFn) {
 
 /**
  * @return {Integer} the number of items that are the same, starting from the 0th index, in a and b
+ * @private
  */
 function commonItemLength(listA, listB) {
   let offset = 0;
@@ -89,6 +91,7 @@ function reduce(enumerable, callback, initialValue) {
 /**
  * @param {Array} array of key1,value1,key2,value2,...
  * @return {Object} {key1:value1, key2:value2, ...}
+ * @private
  */
 function kvArrayToObject(array) {
   const obj = {};

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -56,14 +56,23 @@ function findOffsetInSection(section, node, offset) {
 }
 
 const Position = class Position {
+  /**
+   * A position is a logical location (zero-width, or "collapsed") in a post,
+   * typically between two characters in a section.
+   * Two positions (a head and a tail) make up a {@link Range}.
+   * @constructor
+   */
   constructor(section, offset=0) {
     assert('Position must have a section that is addressable by the cursor',
            (section && section.isLeafSection));
     assert('Position must have numeric offset',
            (offset !== null && offset !== undefined));
 
+    /** @property {Section} section */
     this.section = section;
+    /** @property {number} offset */
     this.offset = offset;
+
     this.isBlank = false;
   }
 
@@ -137,12 +146,11 @@ const Position = class Position {
   }
 
   /**
-   * This method returns a new Position instance, it does not modify
-   * this instance.
+   * Move the position 1 unit in `direction`.
    *
    * @param {Direction} direction to move
-   * @return {Position|null} Return the position one unit in the given
-   * direction, or null if it is not possible to move that direction
+   * @return {Position|null} Return a new position one unit in the given
+   * direction or null if it is not possible to move that direction
    */
   move(direction) {
     switch (direction) {
@@ -288,7 +296,6 @@ const Position = class Position {
     assert('cannot get markerPosition of a non-markerable', !!this.section.isMarkerable);
     return this.section.markerPositionAtOffset(this.offset);
   }
-
 };
 
 export default Position;

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -2,12 +2,38 @@ import Position from './position';
 import { DIRECTION } from '../key';
 
 export default class Range {
+  /**
+   * A logical range of a {@link Post}.
+   * Usually an instance of Range will be read from the {@link Editor#range} property,
+   * but it may be useful to instantiate a range directly in cases
+   * when programmatically modifying a Post.
+   * @constructor
+   * @param {Position} head
+   * @param {Position} [tail=head]
+   * @param {Direction} [direction=null]
+   * @return {Range}
+   */
   constructor(head, tail=head, direction=null) {
+    /** @property {Position} head */
     this.head = head;
+
+    /** @property {Position} tail */
     this.tail = tail;
+
+    /** @property {Direction} direction */
     this.direction = direction;
   }
 
+  /**
+   * Shorthand to create a new range from a section(s) and offset(s).
+   * When given only a head section and offset, creates a collapsed range.
+   * @param {Section} headSection
+   * @param {number} headOffset
+   * @param {Section} [tailSection=headSection]
+   * @param {number} [tailOffset=headOffset]
+   * @param {Direction} [direction=null]
+   * @return {Range}
+   */
   static create(headSection, headOffset, tailSection=headSection, tailOffset=headOffset, direction=null) {
     return new Range(
       new Position(headSection, headOffset),
@@ -32,6 +58,7 @@ export default class Range {
    * wholly contained. It's possible to call `trimTo` with a selection that is
    * outside of the range, though, which would invalidate that assumption.
    * There's no efficient way to determine if a section is within a range, yet.
+   * @private
    */
   trimTo(section) {
     const length = section.length;
@@ -45,39 +72,39 @@ export default class Range {
   }
 
   /**
-   * Expands the range in the given direction
-   * @param {Direction} newDirection
-   * @return {Range} Always returns an expanded, non-collapsed range
+   * Expands the range 1 unit in the given direction
+   * @param {Direction} direction
+   * @return {Range} If the range is expandable in the given direction, always returns a
+   *         non-collapsed range.
    * @public
    */
-  extend(newDirection) {
-    let { head, tail, direction } = this;
-    switch (direction) {
+  extend(direction) {
+    let { head, tail, direction: currentDirection } = this;
+    switch (currentDirection) {
       case DIRECTION.FORWARD:
-        return new Range(head, tail.move(newDirection), direction);
+        return new Range(head, tail.move(direction), currentDirection);
       case DIRECTION.BACKWARD:
-        return new Range(head.move(newDirection), tail, direction);
+        return new Range(head.move(direction), tail, currentDirection);
       default:
-        return new Range(head, tail, newDirection).extend(newDirection);
+        return new Range(head, tail, direction).extend(direction);
     }
   }
 
   /**
-   * Moves this range in {newDirection}.
-   * If the range is collapsed, returns a collapsed range shifted 1 unit in
-   * {newDirection}, otherwise collapses this range to the position at the
-   * {newDirection} end of the range.
-   * @param {Direction} newDirection
+   * Moves this range 1 unit in the given direction.
+   * If the range is collapsed, returns a collapsed range shifted by 1 unit,
+   * otherwise collapses this range to the position at the `direction` end of the range.
+   * @param {Direction} direction
    * @return {Range} Always returns a collapsed range
    * @public
    */
-  move(newDirection) {
+  move(direction) {
     let { focusedPosition, isCollapsed } = this;
 
     if (isCollapsed) {
-      return new Range(focusedPosition.move(newDirection));
+      return new Range(focusedPosition.move(direction));
     } else {
-      return this._collapse(newDirection);
+      return this._collapse(direction);
     }
   }
 

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -52,6 +52,7 @@ function clearChildNodes(element) {
  * (e.g., inclusive containment)  the parent node
  *  see https://github.com/webmodules/node-contains/blob/master/index.js
  *  Mimics the behavior of `Node.contains`, which is broken in IE 10
+ *  @private
  */
 function containsNode(parentNode, childNode) {
   if (parentNode === childNode) {
@@ -66,6 +67,7 @@ function containsNode(parentNode, childNode) {
  * an object with key-value pairs
  * @param {DOMNode} element
  * @return {Object} key-value pairs
+ * @private
  */
 function getAttributes(element) {
   const result = {};

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -1,4 +1,10 @@
 import Keycodes from './keycodes';
+/**
+ * @typedef Direction
+ * @enum {number}
+ * @property {number} FORWARD
+ * @property {number} BACKWARD
+ */
 export const DIRECTION = {
   FORWARD: 1,
   BACKWARD: -1

--- a/src/js/utils/logger.js
+++ b/src/js/utils/logger.js
@@ -6,9 +6,10 @@ let options = {
 
 /**
  * A Logger to add debugging-style logging
- * that can be turned on/off by type of log
+ * that can be turned on/off by type of log.
  *
  * Usage:
+ * ```
  * Logger.enable();
  * Logger.enableTypes(['my-events']);
  * let log = Logger.for('my-events');
@@ -17,6 +18,8 @@ let options = {
  * log = Logger.for('other-events');
  * log('another message'); // => wil not be logged, because 'other-events'
  *                         //    is not enabled
+ * ```
+ * @private
  */
 const Logger = class Logger {
   constructor(type) {

--- a/src/js/utils/merge.js
+++ b/src/js/utils/merge.js
@@ -12,6 +12,7 @@ function mergeWithOptions(original, updates, options) {
 
 /**
  * Merges properties of one object into another
+ * @private
  */
 function merge(original, updates) {
   return mergeWithOptions(original, updates);

--- a/src/js/utils/parse-utils.js
+++ b/src/js/utils/parse-utils.js
@@ -13,6 +13,7 @@ const MOBILEDOC_REGEX = new RegExp(/data\-mobiledoc='(.*?)'>/);
 
 /**
  * @return {Post}
+ * @private
  */
 function parsePostFromHTML(html, builder, plugins) {
   let post;
@@ -30,6 +31,7 @@ function parsePostFromHTML(html, builder, plugins) {
 
 /**
  * @return {Post}
+ * @private
  */
 function parsePostFromText(text, builder, plugins) {
   let parser = new TextParser(builder, {plugins});
@@ -39,6 +41,7 @@ function parsePostFromText(text, builder, plugins) {
 
 /**
  * @return {{html: String, text: String}}
+ * @private
  */
 export function getContentFromPasteEvent(event, window) {
   let html = '', text = '';
@@ -60,6 +63,7 @@ export function getContentFromPasteEvent(event, window) {
 
 /**
  * @return {{html: String, text: String}}
+ * @private
  */
 function getContentFromDropEvent(event) {
   let html = '', text = '';
@@ -81,6 +85,7 @@ function getContentFromDropEvent(event) {
  * @param {CopyEvent|CutEvent}
  * @param {Editor}
  * @param {Window}
+ * @private
  */
 export function setClipboardData(event, {mobiledoc, html, text}, window) {
   if (mobiledoc && html) {
@@ -105,6 +110,7 @@ export function setClipboardData(event, {mobiledoc, html, text}, window) {
  * @param {PasteEvent}
  * @param {{builder: Builder, _parserPlugins: Array}} options
  * @return {Post}
+ * @private
  */
 export function parsePostFromPaste(pasteEvent, {builder, _parserPlugins: plugins}, {targetFormat}={targetFormat:'html'}) {
   let { html, text } = getContentFromPasteEvent(pasteEvent, window);
@@ -120,6 +126,7 @@ export function parsePostFromPaste(pasteEvent, {builder, _parserPlugins: plugins
  * @param {DropEvent}
  * @param {{builder: Builder, _parserPlugins: Array}} options
  * @return {Post}
+ * @private
  */
 export function parsePostFromDrop(dropEvent, {builder, _parserPlugins: plugins}) {
   let { html, text } = getContentFromDropEvent(dropEvent);


### PR DESCRIPTION
Fixes some comments to be proper jsdoc format, explicitly marks some methods as private (jsdoc assumes public unless told otherwise), add `npm run docs` script.