### PR TITLE
[BUGFIX] Ensure inputModeDidChange fires when changing from ol -> ul

### DIFF
--- a/src/js/editor/edit-state.js
+++ b/src/js/editor/edit-state.js
@@ -81,7 +81,11 @@ class EditState {
     };
     // Section objects are 'live', so to check that they changed, we
     // need to map their tagNames now (and compare to mapped tagNames later).
-    state.activeSectionTagNames = state.activeSections.map(s => s.tagName);
+    // In addition, to catch changes from ul -> ol, we keep track of the
+    // un-nested tag names (otherwise we'd only see li -> li change)
+    state.activeSectionTagNames = state.activeSections.map(s => {
+      return s.isNested ? s.parent.tagName : s.tagName;
+    });
     return state;
   }
 

--- a/tests/unit/editor/editor-events-test.js
+++ b/tests/unit/editor/editor-events-test.js
@@ -332,3 +332,22 @@ test('inputModeDidChange callback not fired when moving cursor into same section
     done();
   });
 });
+
+test('inputModeDidChange called when changing from ul to ol', (assert) => {
+  assert.expect(4);
+
+  editor.selectRange(new Range(editor.post.headPosition(), editor.post.tailPosition()));
+
+  let inputChanged = 0;
+  editor.inputModeDidChange(() => inputChanged++);
+
+  editor.toggleSection('ul');
+
+  assert.hasElement('#editor ul li', 'created ul');
+  assert.equal(inputChanged, 1, 'precond - changed to ul');
+
+  editor.toggleSection('ol');
+
+  assert.hasElement('#editor ol li', 'created ol');
+  assert.equal(inputChanged, 2, 'inputModeDidChange fired after ul->ol');
+});


### PR DESCRIPTION
Because `activeSections` is the active leaf sections, their tagNames stay
stable (li -> li) when changing from ol -> ul. This changes EditState's
mapping to be the parent section tag name (ul or ol) for nested sections
(li).