### PR TITLE
Ignore mutation events from within atoms

### DIFF
--- a/src/js/editor/mutation-handler.js
+++ b/src/js/editor/mutation-handler.js
@@ -93,10 +93,15 @@ export default class MutationHandler {
 
       for (let j=0; j < nodes.length; j++) {
         let node = nodes[j];
-        let renderNode = this._findSectionRenderNodeFromNode(node);
+        let renderNode = this._findRenderNodeFromNode(node);
         if (renderNode) {
           if (renderNode.reparsesMutationOfChildNode(node)) {
-            sections.add(renderNode.postNode);
+            let section = this._findSectionFromRenderNode(renderNode);
+            if (section) {
+              sections.add(section);
+            } else {
+              reparsePost = true;
+            }
           }
         } else {
           reparsePost = true;
@@ -138,6 +143,15 @@ export default class MutationHandler {
     return this.renderTree.findRenderNodeFromElement(node, (rn) => {
       return rn.postNode.isSection;
     });
+  }
+
+  _findRenderNodeFromNode(node) {
+    return this.renderTree.findRenderNodeFromElement(node);
+  }
+
+  _findSectionFromRenderNode(renderNode) {
+    let sectionRenderNode = this._findSectionRenderNodeFromNode(renderNode.element);
+    return sectionRenderNode && sectionRenderNode.postNode;
   }
 
 }

--- a/src/js/models/render-node.js
+++ b/src/js/models/render-node.js
@@ -77,6 +77,8 @@ export default class RenderNode extends LinkedItem {
   reparsesMutationOfChildNode(node) {
     if (this.postNode.isCardSection) {
       return !containsNode(this.cardNode.element, node);
+    } else if (this.postNode.isAtom) {
+      return !containsNode(this.atomNode.element, node);
     }
     return true;
   }

--- a/tests/unit/editor/atom-lifecycle-test.js
+++ b/tests/unit/editor/atom-lifecycle-test.js
@@ -234,3 +234,36 @@ test('onTeardown hook is called when editor is destroyed', (assert) => {
 
   assert.ok(teardown, 'onTeardown hook called');
 });
+
+test('mutating the content of an atom does not trigger an update', (assert) => {
+  const done = assert.async();
+
+  const atomName = 'test-atom';
+
+  const atom = {
+    name: atomName,
+    type: 'dom',
+    render() {
+      return makeEl('the-atom');
+    }
+  };
+
+  const mobiledoc = build(({markupSection, post, atom}) =>
+    post([markupSection('p', [atom(atomName, '@bob', {})])])
+  );
+  editor = new Editor({mobiledoc, atoms: [atom]});
+
+  let updateTriggered = false;
+  editor.postDidChange(() => updateTriggered = true);
+
+  assert.hasNoElement('#editor #the-atom', 'precond - atom not rendered');
+  editor.render(editorElement);
+
+  $("#the-atom").html("updated");
+
+  // ensure the mutations have had time to trigger
+  setTimeout(function(){
+    assert.ok(!updateTriggered);
+    done();
+  }, 10);
+});


### PR DESCRIPTION
ember-mobiledoc-editor uses ember-wormhole to insert components into
atom placeholders. This immediately causes a mutation and then
the editor update is triggered when nothing has changed.

Atoms are their own world and so any changes in them should be safe
to ignore.

Delegates the mutation-reparsing logic to RenderNodes.