### PR TITLE
Allow destroying an editor when it failed to render properly

### DIFF
--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -473,6 +473,11 @@ let destroyHooks = {
     // FIXME before we render marker, should delete previous renderNode's element
     // and up until the next marker element
 
+    // If an atom throws during render we may end up later destroying a renderNode
+    // that has not rendered yet, so exit early here if so.
+    if (!renderNode.isRendered) {
+      return;
+    }
     let { markupElement } = renderNode;
 
     if (marker.section) {

--- a/tests/unit/editor/atom-lifecycle-test.js
+++ b/tests/unit/editor/atom-lifecycle-test.js
@@ -12,9 +12,7 @@ module('Unit: Editor: Atom Lifecycle', {
   },
   afterEach() {
     if (editor) {
-      try {
-        editor.destroy();
-      } catch(e) {}
+      editor.destroy();
       editor = null;
     }
   }
@@ -206,8 +204,6 @@ test('rendering unknown atom without unknownAtomHandler throws', (assert) => {
     editor.render(editorElement);
   }, new RegExp(`Unknown atom "${atomName}".*no unknownAtomHandler`));
 });
-
-
 
 test('onTeardown hook is called when editor is destroyed', (assert) => {
   const atomName = 'test-atom';


### PR DESCRIPTION
If the editor throws an error while rendering an atom, later calling
`editor.destroy` can create issues. This ensures that the editor-dom
renderer doesn't choke when destroying an atom renderNode if it didn't
properly render.