### PR TITLE
Build docs when building website

### DIFF
--- a/.jsdoc
+++ b/.jsdoc
@@ -5,7 +5,7 @@
   "opts": {
     "readme": "./README.md",
     "recurse": true,
-    "destination": "./demo/public/docs"
+    "destination": "./docs"
   },
   "plugins": [
     "plugins/markdown"

--- a/bin/build-website.sh
+++ b/bin/build-website.sh
@@ -15,6 +15,10 @@ mkdir -p website/demo
 echo "Copying $(pwd)/demo/dist/* to $(pwd)/website/demo"
 cp -R demo/dist/* website/demo/
 
+echo "Copying $(pwd)/docs to $(pwd)/website/demo"
+mkdir -p website/demo/docs
+cp -R docs/* website/demo/docs/
+
 CURRENT_SHA="$(git rev-parse HEAD)"
 git add website/
 git commit -m "built website from $CURRENT_SHA"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:ci": "npm run build && testem ci -f testem-ci.json",
     "test": "npm run build && testem ci -f testem.json",
     "build": "rm -rf dist && broccoli build dist",
-    "build-website": "./bin/build-website.sh",
+    "build-website": "npm run docs && ./bin/build-website.sh",
     "deploy-website": "./bin/deploy-website.sh",
     "update-changelog": "conventional-changelog -i CHANGELOG.md -r 0 -s",
     "docs": "jsdoc -c ./.jsdoc"


### PR DESCRIPTION
Change `npm run build-website` to build docs and include them in built website.