### PR TITLE
Added support to CMD+Left/Right for Mac navigation

### DIFF
--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -11,6 +11,22 @@ function selectAll(editor) {
   editor.selectRange(allRange);
 }
 
+function gotoStartOfLine(editor) {
+  let {range} = editor;
+  let {tail: {section}} = range;
+  editor.run(postEditor => {
+    postEditor.setRange(new Range(section.headPosition()));
+  });
+}
+
+function gotoEndOfLine(editor) {
+  let {range} = editor;
+  let {tail: {section}} = range;
+  editor.run(postEditor => {
+    postEditor.setRange(new Range(section.tailPosition()));
+  });
+}
+
 export const DEFAULT_KEY_COMMANDS = [{
   str: 'META+B',
   run(editor) {
@@ -47,13 +63,16 @@ export const DEFAULT_KEY_COMMANDS = [{
   str: 'CTRL+A',
   run(editor) {
     if (Browser.isMac) {
-      let {range} = editor;
-      let {head: {section}} = range;
-      editor.run(postEditor => {
-        postEditor.setRange(new Range(section.headPosition()));
-      });
+      gotoStartOfLine(editor);
     } else {
       selectAll(editor);
+    }
+  }
+}, {
+  str: 'META+LEFT',
+  run(editor) {
+    if (Browser.isMac) {
+      gotoStartOfLine(editor);
     }
   }
 }, {
@@ -66,12 +85,16 @@ export const DEFAULT_KEY_COMMANDS = [{
 }, {
   str: 'CTRL+E',
   run(editor) {
-    if (!Browser.isMac) { return false; }
-    let {range} = editor;
-    let {tail: {section}} = range;
-    editor.run(postEditor => {
-      postEditor.setRange(new Range(section.tailPosition()));
-    });
+    if (Browser.isMac) {
+      gotoEndOfLine(editor);
+    }
+  }
+}, {
+  str: 'META+RIGHT',
+  run(editor) {
+    if (Browser.isMac) {
+      gotoEndOfLine(editor);
+    }
   }
 }, {
   str: 'META+K',

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -235,7 +235,7 @@ function triggerKeyCommand(editor, string, modifiers=[]) {
   if (typeof modifiers === "number") {
     modifiers = [modifiers]; // convert singular to array
   }
-  let charCode = string.toUpperCase().charCodeAt(0);
+  let charCode = (KEY_CODES[string] || string.toUpperCase().charCodeAt(0));
   let keyCode = charCode;
   let keyEvent = createMockEvent('keydown', editor.element, {
     charCode,


### PR DESCRIPTION
In MacOS, in addition to CTRL+A and E for "Home" and "End", another commonly used combination is CMD+Left for Home, and CMD+Right for End.

This commit adds those shortcuts, and pulls out the "getStartOfLine" and "getEndOfLine" functions out so they can respond to multiple command keys.

Regarding tests: I didn't find any tests for the existing Home/End key commands, so I didn't add anymore. But I have run the test suite and have noted no regressions.
