### PR TITLE
Add didrender hook

### DIFF
--- a/src/js/models/card-node.js
+++ b/src/js/models/card-node.js
@@ -46,11 +46,18 @@ export default class CardNode {
     }
   }
 
+  didRender() {
+    if (this._didRenderCallback) {
+      this._didRenderCallback();
+    }
+  }
+
   get env() {
     return {
       name: this.card.name,
       isInEditor: true,
       onTeardown: (callback) => this._teardownCallback = callback,
+      didRender: (callback) => this._didRenderCallback = callback,
       edit: () => this.edit(),
       save: (payload, transition=true) => {
         this.section.payload = payload;
@@ -90,5 +97,6 @@ export default class CardNode {
     );
     this.element.appendChild(rendered);
     this._rendered = rendered;
+    this.didRender();
   }
 }

--- a/tests/unit/editor/card-lifecycle-test.js
+++ b/tests/unit/editor/card-lifecycle-test.js
@@ -620,7 +620,7 @@ test('didRender hook is called when moving from display->edit and back', (assert
   editor.render(editorElement);
 
   assert.equal(currentMode, 'display', 'precond - display mode');
-  assert.ok(rendered, 'render called on instantiation');
+  assert.ok(rendered, 'didRender called on instantiation');
 
   editHook();
 


### PR DESCRIPTION
Fires once card has been rendered, for use by cards that need processing after they've been added to the DOM (e.g. 3rd-party widgets.)

This is my first time in this codebase, so I don't expect this to be complete. Specifically:

- Did I overlook any cases where this hook should (or should not) fire?
- Would it be useful for the callback take any args, such as the current `env`?
- I based this on the `onTeardown` hook. Is the `env.didRender` pattern preferable to adding another optional `didRender` property to the top-level card object?

Thanks for your feedback!