### PR TITLE
Use trusty dist and phantomjs-prebuilt at travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
 ---
 language: node_js
 node_js:
-  - "5.4.1"
+  - "stable"
 
-sudo: false
+sudo: required
+dist: trusty
 
 cache:
   directories:
     - node_modules
 
 before_install:
-  # See https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
-  - mkdir travis-phantomjs
-  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
-  - echo $(phantomjs --version)
-  - npm config set spin false
+  - npm install -g npm@^3
+  - npm config set progress false
+  - npm install phantomjs-prebuilt
 
 install:
   - npm install -g broccoli-cli
-  - npm install -g bower
-  - bower install
   - npm install
 
 script:


### PR DESCRIPTION
Our build sometimes false-positives when it gets rate-limited by bitbucket downloading phantomjs.
This should make builds more consistent at travis.
Opts in to the Travis "Trusty" beta dist: https://docs.travis-ci.com/user/trusty-ci-environment/