### PR TITLE
Handling emoji's on iOS Safari

### DIFF
--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -51,11 +51,7 @@ export const SPECIAL_KEYS = {
 
 // heuristic for determining if `event` is a key event
 function isKeyEvent(event) {
-  return !!event.charCode ||
-    !!event.keyCode ||
-    !!event.metaKey ||
-    !!event.shiftKey ||
-    !!event.ctrlKey;
+  return /^key/.test(event.type);
 }
 
 /**

--- a/tests/unit/utils/key-test.js
+++ b/tests/unit/utils/key-test.js
@@ -8,7 +8,8 @@ const {module, test} = Helpers;
 module('Unit: Utils: Key');
 
 test('#hasModifier with no modifier', (assert) => {
-  const key = Key.fromEvent({ keyCode: 42 });
+  const event = Helpers.dom.createMockEvent('keydown', null, { keyCode: 42 });
+  const key = Key.fromEvent(event);
 
   assert.ok(!key.hasModifier(MODIFIERS.META), "META not pressed");
   assert.ok(!key.hasModifier(MODIFIERS.CTRL), "CTRL not pressed");
@@ -16,7 +17,8 @@ test('#hasModifier with no modifier', (assert) => {
 });
 
 test('#hasModifier with META', (assert) => {
-  const key = Key.fromEvent({ metaKey: true });
+  const event = Helpers.dom.createMockEvent('keyup', null, { metaKey: true });
+  const key = Key.fromEvent(event);
 
   assert.ok(key.hasModifier(MODIFIERS.META), "META pressed");
   assert.ok(!key.hasModifier(MODIFIERS.CTRL), "CTRL not pressed");
@@ -24,7 +26,8 @@ test('#hasModifier with META', (assert) => {
 });
 
 test('#hasModifier with CTRL', (assert) => {
-  const key = Key.fromEvent({ ctrlKey: true });
+  const event = Helpers.dom.createMockEvent('keypress', null, { ctrlKey: true });
+  const key = Key.fromEvent(event);
 
   assert.ok(!key.hasModifier(MODIFIERS.META), "META not pressed");
   assert.ok(key.hasModifier(MODIFIERS.CTRL), "CTRL pressed");
@@ -32,7 +35,8 @@ test('#hasModifier with CTRL', (assert) => {
 });
 
 test('#hasModifier with SHIFT', (assert) => {
-  const key = Key.fromEvent({ shiftKey: true });
+  const event = Helpers.dom.createMockEvent('keydown', null, { shiftKey: true });
+  const key = Key.fromEvent(event);
 
   assert.ok(!key.hasModifier(MODIFIERS.META), "META not pressed");
   assert.ok(!key.hasModifier(MODIFIERS.CTRL), "CTRL not pressed");


### PR DESCRIPTION
iPads have emoji's on their virtual keyboard. However, this causes problems with mobiledoc-kit as both the `charCode` and the `keyCode` are 0 for the `keydown` and `keyup` events when inputting one of those emojis. To illustrate, I used the Keyboard Event Viewer (https://w3c.github.io/uievents/tools/key-event-viewer.html):

![emoji](https://cloud.githubusercontent.com/assets/1374412/15197082/e6075342-17a5-11e6-95d6-4f3276558fc1.png)

This causes the assert at https://github.com/bustlelabs/mobiledoc-kit/blob/3cb78311cc0ffc57067537488586a986e2179adc/src/js/utils/key.js#L75 to fail.

I solved it by changing the heuristic to determine whether an event is a key event to checking whether the type is one of `keypress`, `keydown` or `keybottom`. According to the [doc](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent), any key event has one of these values. Also, this is the heuristic that is used by jQuery (see https://github.com/jquery/jquery/blob/master/src/event.js#L627).