### PR TITLE
Prevent 'Invalid argument' error when triple-clicking to select on IE

### DIFF
--- a/src/js/utils/selection-utils.js
+++ b/src/js/utils/selection-utils.js
@@ -99,9 +99,21 @@ function comparePosition(selection) {
   // made.
   //
   if (position & Node.DOCUMENT_POSITION_CONTAINS) {
+    if (focusOffset < focusNode.childNodes.length) {
+      focusNode = focusNode.childNodes[focusOffset];
+      focusOffset = 0;
+    } else {
+      // This situation happens on IE when triple-clicking to select.
+      // Set the focus to the very last character inside the node.
+      while (focusNode.lastChild) {
+        focusNode = focusNode.lastChild;
+      }
+      focusOffset = focusNode.textContent.length;
+    }
+
     return comparePosition({
-      focusNode: focusNode.childNodes[focusOffset],
-      focusOffset: 0,
+      focusNode,
+      focusOffset,
       anchorNode, anchorOffset
     });
   } else if (position & Node.DOCUMENT_POSITION_CONTAINED_BY) {


### PR DESCRIPTION
On IE11 and Edge, triple-clicking on `This is Mobiledoc-kit` on the [demo](https://bustlelabs.github.io/mobiledoc-kit/demo/) to select it throws an `Invalid argument` error.

The reason is that an `undefined` value for `focusNode` is given as an argument to `compareDocumentPosition` on https://github.com/bustlelabs/mobiledoc-kit/blob/0f6d2324fe23b10de0783483ee01163a7d8d4236/src/js/utils/selection-utils.js#L87. I traced it back to it happening in the recursive call https://github.com/bustlelabs/mobiledoc-kit/blob/0f6d2324fe23b10de0783483ee01163a7d8d4236/src/js/utils/selection-utils.js#L102.

The problem is that in the outer call, `focusNode` is set to the editor `<div>` element with a `focusOffset` of 2. Then `focusNode.childNodes[focusOffset]` is `undefined` as it only contains 2 elements. I looked up why IE does this but couldn't find anything.

As a solution, when such a case happens, I set the focus to the very last character in the node. I think that achieves the intent.