### PR TITLE
Add line selection shortcuts

### DIFF
--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -1,5 +1,5 @@
 import Key from '../utils/key';
-import { MODIFIERS, SPECIAL_KEYS } from '../utils/key';
+import { MODIFIERS, SPECIAL_KEYS, DIRECTION } from '../utils/key';
 import { filter, reduce } from '../utils/array-utils';
 import assert from '../utils/assert';
 import Range from '../utils/cursor/range';
@@ -25,6 +25,24 @@ function gotoEndOfLine(editor) {
   editor.run(postEditor => {
     postEditor.setRange(new Range(section.tailPosition()));
   });
+}
+
+function selectLineToLeft(editor) {
+  let {range} = editor;
+  let {tail: {section}} = range;
+  let selectionRange = new Range(section.headPosition(), range.tail);
+
+  selectionRange.direction = DIRECTION.BACKWARD;
+  editor.selectRange(selectionRange);
+}
+
+function selectLineToRight(editor) {
+  let {range} = editor;
+  let {tail: {section}} = range;
+  let selectionRange = new Range(range.head, section.tailPosition());
+
+  selectionRange.direction = DIRECTION.FORWARD;
+  editor.selectRange(selectionRange);
 }
 
 export const DEFAULT_KEY_COMMANDS = [{
@@ -76,6 +94,13 @@ export const DEFAULT_KEY_COMMANDS = [{
     }
   }
 }, {
+  str: 'META+SHIFT+LEFT',
+  run(editor) {
+    if (Browser.isMac) {
+      selectLineToLeft(editor);
+    }
+  }
+},{
   str: 'META+A',
   run(editor) {
     if (Browser.isMac) {
@@ -94,6 +119,13 @@ export const DEFAULT_KEY_COMMANDS = [{
   run(editor) {
     if (Browser.isMac) {
       gotoEndOfLine(editor);
+    }
+  }
+}, {
+  str: 'META+SHIFT+RIGHT',
+  run(editor) {
+    if (Browser.isMac) {
+      selectLineToRight(editor);
     }
   }
 }, {

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -196,6 +196,57 @@ test(`cmd-right goes to the end of a line (MacOS only)`, (assert) => {
   }
 });
 
+test(`cmd-shif-left select text to the beginning of a line (MacOS only)`, (assert) => {
+  let initialText = 'something';
+  editor = renderIntoAndFocusTail(({post, markupSection, marker}) => post([
+    markupSection('p', [marker(initialText)])
+  ]));
+
+  assert.ok(editor.hasCursor(), 'has cursor');
+
+  let textElement = editor.post.sections.head.markers.head.renderNode.element;
+
+  Helpers.dom.moveCursorTo(editor, textElement, 4);
+  let originalCursorPosition = Helpers.dom.getCursorPosition();
+
+  Helpers.dom.triggerKeyCommand(editor, 'LEFT', [MODIFIERS.META, MODIFIERS.SHIFT]);
+
+  let changedCursorPosition = Helpers.dom.getCursorPosition();
+
+  if (Browser.isMac) {
+    assert.positionIsEqual(editor.range.head, editor.post.headPosition());
+    assert.equal(editor.range.tail.offset, originalCursorPosition.offset);
+
+  } else {
+    assert.equal(changedCursorPosition.offset, originalCursorPosition.offset, 'cursor not moved to the end of the line (non-MacOS)');
+  }
+});
+
+test(`cmd-shif-right select text to the end of a line (MacOS only)`, (assert) => {
+  let initialText = 'something';
+  editor = renderIntoAndFocusTail(({post, markupSection, marker}) => post([
+    markupSection('p', [marker(initialText)])
+  ]));
+
+  assert.ok(editor.hasCursor(), 'has cursor');
+
+  let textElement = editor.post.sections.head.markers.head.renderNode.element;
+
+  Helpers.dom.moveCursorTo(editor, textElement, 4);
+  let originalCursorPosition = Helpers.dom.getCursorPosition();
+
+  Helpers.dom.triggerKeyCommand(editor, 'RIGHT', [MODIFIERS.META, MODIFIERS.SHIFT]);
+
+  let changedCursorPosition = Helpers.dom.getCursorPosition();
+
+  if (Browser.isMac) {
+    assert.positionIsEqual(editor.range.head.offset, originalCursorPosition.offset);
+    assert.positionIsEqual(editor.range.tail, editor.post.tailPosition());
+
+  } else {
+    assert.equal(changedCursorPosition.offset, initialText.length, 'cursor not moved to the end of the line (non-MacOS)');
+  }
+});
 test(`ctrl-k clears to the end of a line`, (assert) => {
   let initialText = 'something';
   editor = renderIntoAndFocusTail(({post, markupSection, marker}) => post([


### PR DESCRIPTION
This PR is intended to introduce line selection functionality on OS X:

- when user press `CMD+SHIFT+LEFT` text is selected from the cursor position till the beginning of the line
- when user press `CMD+SHIFT+RIGHT` text is selected from the cursor position till the end of the line