### PR TITLE
fastboot-friendly browser test

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -1,3 +1,3 @@
 export default {
-  isMac: /Mac/.test(navigator.platform)
+  isMac: window.navigator && /Mac/.test(window.navigator.platform)
 };


### PR DESCRIPTION
we're encountering some fastboot errors when `ember-mobile-editor/utils/create-component-card` is invoked in fastboot because of this 