### PR TITLE
Document `Editor({ mobiledoc: ... })` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ editor.render(element);
 
 `options` is an object which may include the following properties:
 
+* `modiledoc` - [object] A mobiledoc object to load and edit.
 * `placeholder` - [string] default text to show before a user starts typing.
 * `spellcheck` - [boolean] whether to enable spellcheck. Defaults to true.
 * `autofocus` - [boolean] When true, focuses on the editor when it is rendered.


### PR DESCRIPTION
It was used in the example, but not listed as an available option.