### PR TITLE
Render prettier mobiledocs in the demo app

### DIFF
--- a/demo/app/helpers/format-object.js
+++ b/demo/app/helpers/format-object.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
+import formatMobiledoc from 'npm:mobiledoc-pretty-json-renderer';
 
 export function formatObject([object]) {
-  return JSON.stringify(object, null, '  ');
+  return formatMobiledoc(object);
 }
 
 export default Ember.Helper.helper(formatObject);

--- a/demo/package.json
+++ b/demo/package.json
@@ -38,5 +38,9 @@
     "ember-mobiledoc-dom-renderer": "^0.4.1",
     "ember-mobiledoc-html-renderer": "^0.3.0",
     "ember-mobiledoc-text-renderer": "^0.3.0"
+  },
+  "dependencies": {
+    "ember-browserify": "^1.1.9",
+    "mobiledoc-pretty-json-renderer": "^2.0.0"
   }
 }


### PR DESCRIPTION
This makes the docs in the demo app easier to read:
<img width="921" alt="screen shot 2016-06-11 at 1 33 39 pm" src="https://cloud.githubusercontent.com/assets/1588273/15986601/b2b6f7a8-2fd9-11e6-8420-4df335aba94a.png">
Compared to existing:
<img width="931" alt="screen shot 2016-06-11 at 1 34 02 pm" src="https://cloud.githubusercontent.com/assets/1588273/15986610/cba11e4c-2fd9-11e6-9211-e51a3561abc0.png">

The main drawback right now is that it was only really written for 0.3.0 docs. 0.2.0 docs look a little wonky:
<img width="934" alt="screen shot 2016-06-11 at 1 38 53 pm" src="https://cloud.githubusercontent.com/assets/1588273/15986619/16852246-2fda-11e6-9bb9-91f96d8c3227.png">

