### PR TITLE
It's useful to expose replace section functions

### DIFF
--- a/src/js/editor/text-input-handlers.js
+++ b/src/js/editor/text-input-handlers.js
@@ -1,6 +1,6 @@
 import Range from 'mobiledoc-kit/utils/cursor/range';
 
-function replaceWithListSection(editor, listTagName) {
+export function replaceWithListSection(editor, listTagName) {
   let { range: { head, head: { section } } } = editor;
   // Skip if cursor is not at end of section
   if (!head.isTail()) {
@@ -21,7 +21,7 @@ function replaceWithListSection(editor, listTagName) {
   });
 }
 
-function replaceWithHeaderSection(editor, headingTagName) {
+export function replaceWithHeaderSection(editor, headingTagName) {
   let { range: { head, head: { section } } } = editor;
   // Skip if cursor is not at end of section
   if (!head.isTail()) {


### PR DESCRIPTION
In case of extending text input handlers by users, it would be useful not copy/pasting`replaceWithListSection`/`replaceWithHeaderSection`. For example if I just want to add a new handler to convert section to `backquote`, I can easily import replaceWithHeaderSection from this file without implementing this function again. So I propose to expose these two functions.