### PR TITLE
Return cards and atoms from high-level insert methods

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -908,6 +908,7 @@ class Editor {
    * @param {String} atomName
    * @param {String} [atomText='']
    * @param {Object} [atomPayload={}]
+   * @return {Atom} The inserted atom.
    * @public
    */
   insertAtom(atomName, atomText='', atomPayload={}) {
@@ -915,17 +916,20 @@ class Editor {
     if (this.post.isBlank) {
       this._insertEmptyMarkupSectionAtCursor();
     }
+
+    let atom;
     let { range } = this;
     this.run(postEditor => {
       let position = range.head;
 
-      let atom = postEditor.builder.createAtom(atomName, atomText, atomPayload);
+      atom = postEditor.builder.createAtom(atomName, atomText, atomPayload);
       if (!range.isCollapsed) {
         position = postEditor.deleteRange(range);
       }
 
       postEditor.insertMarkers(position, [atom]);
     });
+    return atom;
   }
 
   /**
@@ -937,6 +941,7 @@ class Editor {
    * @param {String} cardName
    * @param {Object} [cardPayload={}]
    * @param {Boolean} [inEditMode=false] Whether the card should be inserted in edit mode.
+   * @return {Card} The inserted Card section.
    * @public
    */
   insertCard(cardName, cardPayload={}, inEditMode=false) {
@@ -945,10 +950,11 @@ class Editor {
       this._insertEmptyMarkupSectionAtCursor();
     }
 
+    let card;
     let { range } = this;
     this.run(postEditor => {
       let position = range.tail;
-      let card = postEditor.builder.createCardSection(cardName, cardPayload);
+      card = postEditor.builder.createCardSection(cardName, cardPayload);
       if (inEditMode) {
         this.editCard(card);
       }
@@ -977,6 +983,7 @@ class Editor {
       // See: https://github.com/bustlelabs/mobiledoc-kit/issues/286
       postEditor.setRange(new Range(card.tailPosition()));
     });
+    return card;
   }
 
   /**

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -506,6 +506,23 @@ test('#insertAtom when post is blank', (assert) => {
   assert.postIsSimilar(editor.post, expected);
 });
 
+test('#insertAtom returns the inserted atom', (assert) => {
+  let atom = {
+    name: 'the-atom',
+    type: 'dom',
+    render() {
+    }
+  };
+
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post}) => {
+    return post();
+  }, {atoms: [atom]});
+
+  const insertedAtom = editor.insertAtom('the-atom', 'THEATOMTEXT');
+
+  assert.equal(insertedAtom.value, 'THEATOMTEXT', 'return value is the inserted atom');
+});
+
 test('#insertCard inserts card at section after cursor position, replacing range if non-collapsed', (assert) => {
   let card = {
     name: 'the-card',
@@ -611,4 +628,21 @@ test('#insertCard when post is blank', (assert) => {
   editor.insertCard('the-card');
 
   assert.postIsSimilar(editor.post, expected, 'adds card section');
+});
+
+test('#insertCard returns card object', (assert) => {
+  let card = {
+    name: 'the-card',
+    type: 'dom',
+    render() {
+    }
+  };
+
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post}) => {
+    return post();
+  }, {cards: [card]});
+
+  const insertedCard = editor.insertCard('the-card');
+
+  assert.equal(editor.post.sections.tail, insertedCard, 'returned card is the inserted card');
 });


### PR DESCRIPTION
It can be useful to get a handle on newly inserted cards/atoms. Currently the only way to do that is to drop to the lower-level `postEditor` methods. This keeps the convenience of high-level insert behavior (range detection, nested/blank sections, &c) while enabling additional operations on the inserted element.