### PR TITLE
Use selection polling to update editor.range

### DIFF
--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -69,13 +69,6 @@ export const DEFAULT_KEY_COMMANDS = [{
     }
   }
 }, {
-  str: 'META+LEFT',
-  run(editor) {
-    if (Browser.isMac) {
-      gotoStartOfLine(editor);
-    }
-  }
-}, {
   str: 'META+A',
   run(editor) {
     if (Browser.isMac) {
@@ -84,13 +77,6 @@ export const DEFAULT_KEY_COMMANDS = [{
   }
 }, {
   str: 'CTRL+E',
-  run(editor) {
-    if (Browser.isMac) {
-      gotoEndOfLine(editor);
-    }
-  }
-}, {
-  str: 'META+RIGHT',
   run(editor) {
     if (Browser.isMac) {
       gotoEndOfLine(editor);

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -41,7 +41,7 @@ class PostEditor {
 
     this._didComplete = false;
 
-    this._renderRange = () => this.editor.renderRange(this._range);
+    this._renderRange = () => this.editor.selectRange(this._range);
     this._postDidChange = () => this.editor._postDidChange();
     this._rerender = () => this.editor.rerender();
   }
@@ -1344,8 +1344,6 @@ class PostEditor {
     this._didComplete = true;
     this.runCallbacks(CALLBACK_QUEUES.COMPLETE);
     this.runCallbacks(CALLBACK_QUEUES.AFTER_COMPLETE);
-
-    this.editor._notifyRangeChange();
   }
 
   undoLastChange() {

--- a/src/js/editor/selection-change-observer.js
+++ b/src/js/editor/selection-change-observer.js
@@ -1,0 +1,99 @@
+let instance;
+
+class SelectionChangeObserver {
+  constructor() {
+    this.started   = false;
+    this.listeners  = [];
+    this.selection = {};
+  }
+
+  static getInstance() {
+    if (!instance) {
+      instance = new SelectionChangeObserver();
+    }
+    return instance;
+  }
+
+  static addListener(listener) {
+    SelectionChangeObserver.getInstance().addListener(listener);
+  }
+
+  addListener(listener) {
+    if (this.listeners.indexOf(listener) === -1) {
+      this.listeners.push(listener);
+      this.start();
+    }
+  }
+
+  static removeListener(listener) {
+    SelectionChangeObserver.getInstance().removeListener(listener);
+  }
+
+  removeListener(listener) {
+    let index = this.listeners.indexOf(listener);
+    if (index !== -1) {
+      this.listeners.splice(index, 1);
+      if (this.listeners.length === 0) {
+        this.stop();
+      }
+    }
+  }
+
+  start() {
+    if (this.started) { return; }
+    this.started = true;
+
+    this.poll();
+  }
+
+  stop() {
+    this.started = false;
+    this.selection = {};
+  }
+
+  notifyListeners(/* newSelection, prevSelection */) {
+    this.listeners.forEach(listener => {
+      listener.selectionDidChange(...arguments);
+    });
+  }
+
+  destroy() {
+    this.stop();
+    this.listeners = [];
+  }
+
+  getSelection() {
+    let selection = window.getSelection();
+    let { anchorNode, focusNode, anchorOffset, focusOffset } = selection;
+    return { anchorNode, focusNode, anchorOffset, focusOffset };
+  }
+
+  poll() {
+    if (this.started) {
+      this.update();
+      this.runNext(() => this.poll());
+    }
+  }
+
+  runNext(fn) {
+    window.requestAnimationFrame(fn);
+  }
+
+  update() {
+    let prevSelection = this.selection;
+    let curSelection = this.getSelection();
+    if (!this.selectionIsEqual(prevSelection, curSelection)) {
+      this.selection = curSelection;
+      this.notifyListeners(curSelection, prevSelection);
+    }
+  }
+
+  selectionIsEqual(s1, s2) {
+    return s1.anchorNode === s2.anchorNode &&
+      s1.anchorOffset === s2.anchorOffset &&
+      s1.focusNode === s2.focusNode &&
+      s1.focusOffset === s2.focusOffset;
+  }
+}
+
+export default SelectionChangeObserver;

--- a/src/js/editor/selection-manager.js
+++ b/src/js/editor/selection-manager.js
@@ -1,0 +1,31 @@
+import SelectionChangeObserver from 'mobiledoc-kit/editor/selection-change-observer';
+
+export default class SelectionManager {
+  constructor(editor, callback) {
+    this.editor   = editor;
+    this.callback = callback;
+    this.started  = false;
+  }
+
+  start() {
+    if (this.started) { return; }
+
+    SelectionChangeObserver.addListener(this);
+    this.started = true;
+  }
+
+  stop() {
+    this.started = false;
+    SelectionChangeObserver.removeListener(this);
+  }
+
+  destroy() {
+    this.stop();
+  }
+
+  selectionDidChange() {
+    if (this.started) {
+      this.callback(...arguments);
+    }
+  }
+}

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -90,17 +90,18 @@ const Key = class Key {
     return this.keyCode === Keycodes.DELETE;
   }
 
-  isMovement() {
-    return this.isArrow() || this.isHome() || this.isEnd();
-  }
-
   isArrow() {
     return this.isHorizontalArrow() || this.isVerticalArrow();
   }
 
   isHorizontalArrow() {
     return this.keyCode === Keycodes.LEFT ||
-      this.keyCode === Keycodes.RIGHT;
+           this.keyCode === Keycodes.RIGHT;
+  }
+
+  isHorizontalArrowWithoutModifiersOtherThanShift() {
+    return this.isHorizontalArrow() &&
+      !(this.ctrlKey || this.metaKey || this.altKey);
   }
 
   isVerticalArrow() {
@@ -209,6 +210,7 @@ const Key = class Key {
     }
 
     return (
+      code !== 0 ||
       this.toString().length > 0 ||
       (code >= Keycodes['0'] && code <= Keycodes['9']) ||         // number keys
       this.isSpace() ||

--- a/src/js/views/view.js
+++ b/src/js/views/view.js
@@ -44,7 +44,7 @@ class View {
   destroy() {
     this.removeAllEventListeners();
     this.hide();
-    this._isDestroyed = true;
+    this.isDestroyed = true;
   }
 }
 

--- a/testem-ci.json
+++ b/testem-ci.json
@@ -1,7 +1,7 @@
 {
   "framework": "qunit",
   "parallel": 6,
-  "test_page": "dist/tests/index.html",
+  "test_page": "dist/tests/index.html?hidepassed",
   "on_start": "./sauce_labs/saucie-connect.js",
   "on_exit": "./sauce_labs/saucie-disconnect.js",
   "port": 8080,

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -87,7 +87,7 @@ test('clicking outside the editor does not raise an error', (assert) => {
 
   Helpers.dom.triggerEvent(editorElement, 'click');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.ok(true, 'can click external item without error');
     secondEditor.destroy();
     document.body.removeChild(secondEditorElement);
@@ -161,7 +161,7 @@ test('typing tab enters a tab character', (assert) => {
   Helpers.dom.moveCursorTo(editor, $('#editor')[0]);
   Helpers.dom.insertText(editor, TAB);
   Helpers.dom.insertText(editor, 'Y');
-  window.setTimeout(() => {
+  Helpers.wait(() => {
     let expectedPost = Helpers.postAbstract.build(({post, markupSection, marker}) => {
       return post([
         markupSection('p', [
@@ -191,13 +191,17 @@ test('select-all and type text works ok', (assert) => {
 
   assert.selectedText('abc', 'precond - abc is selected');
   assert.hasElement('#editor p:contains(abc)', 'precond - renders p');
+  
+  Helpers.wait(() => {
+    Helpers.dom.insertText(editor, 'X');
 
-  Helpers.dom.insertText(editor, 'X');
-  setTimeout(function() {
-    assert.hasNoElement('#editor p:contains(abc)', 'replaces existing text');
-    assert.hasElement('#editor p:contains(X)', 'inserts text');
-    done();
-  }, 0);
+    Helpers.wait(function() {
+      assert.hasNoElement('#editor p:contains(abc)', 'replaces existing text');
+      assert.hasElement('#editor p:contains(X)', 'inserts text');
+      done();
+    });
+  });
+
 });
 
 test('typing enter splits lines, sets cursor', (assert) => {
@@ -214,7 +218,7 @@ test('typing enter splits lines, sets cursor', (assert) => {
 
   Helpers.dom.moveCursorTo(editor, $('#editor p')[0].firstChild, 2);
   Helpers.dom.insertText(editor, ENTER);
-  window.setTimeout(() => {
+  Helpers.wait(() => {
     let expectedPost = Helpers.postAbstract.build(({post, markupSection, marker}) => {
       return post([
         markupSection('p', [
@@ -229,7 +233,7 @@ test('typing enter splits lines, sets cursor', (assert) => {
     let expectedRange = new Range(new Position(editor.post.sections.tail, 0));
     assert.ok(expectedRange.isEqual(editor.range), 'range is at start of new section');
     done();
-  }, 0);
+  });
 });
 
 // see https://github.com/bustlelabs/mobiledoc-kit/issues/306
@@ -264,6 +268,7 @@ test('adding/removing bold text between two bold markers works', (assert) => {
 });
 
 test('keypress events when the editor does not have selection are ignored', (assert) => {
+  let done = assert.async();
   let expected;
   editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
     expected = post([markupSection('p', [marker('abc')])]);
@@ -274,10 +279,11 @@ test('keypress events when the editor does not have selection are ignored', (ass
 
   Helpers.dom.clearSelection();
 
-  assert.ok(document.activeElement === editorElement, 'precond - editor is focused');
-  assert.equal(window.getSelection().rangeCount, 0, 'nothing selected');
+  Helpers.wait(() => {
+    assert.ok(!editor.hasCursor(), 'precond - editor does not have cursor');
+    Helpers.dom.insertText(editor, 'v');
 
-  Helpers.dom.insertText(editor, 'v');
-
-  assert.postIsSimilar(editor.post, expected, 'post is not changed');
+    assert.postIsSimilar(editor.post, expected, 'post is not changed');
+    done();
+  });
 });

--- a/tests/acceptance/editor-atoms-test.js
+++ b/tests/acceptance/editor-atoms-test.js
@@ -59,7 +59,7 @@ test('keystroke of character before starting atom inserts character', (assert) =
   editor.selectRange(new Range(editor.post.headPosition()));
   Helpers.dom.insertText(editor, 'A');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();
@@ -78,7 +78,7 @@ test('keystroke of character before mid-text atom inserts character', (assert) =
   editor.selectRange(Range.create(editor.post.sections.head, 'AB'.length));
   Helpers.dom.insertText(editor, 'C');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();
@@ -97,7 +97,7 @@ test('keystroke of character after mid-text atom inserts character', (assert) =>
   editor.selectRange(Range.create(editor.post.sections.head, 1));
   Helpers.dom.insertText(editor, 'A');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();
@@ -116,7 +116,7 @@ test('keystroke of character after end-text atom inserts character', (assert) =>
   editor.selectRange(Range.create(editor.post.sections.head, 1));
   Helpers.dom.insertText(editor, 'A');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();
@@ -291,26 +291,34 @@ test('keystroke of enter at list item head before atom creates new section', (as
 });
 
 test('marking atom with markup adds markup', (assert) => {
+  assert.expect(1);
+  let done = assert.async();
+
   editor = new Editor({mobiledoc: mobiledocWithAtom, atoms: [simpleAtom]});
   editor.render(editorElement);
 
   let pNode = $('#editor p')[0];
   Helpers.dom.selectRange(pNode.firstChild, 16, pNode.lastChild, 0);
-  editor.run(postEditor => {
-    let markup = editor.builder.createMarkup('strong');
-    postEditor.addMarkupToRange(editor.range, markup);
-  });
 
-  assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
-    ({post, markupSection, atom, marker, markup}) => {
-      return post([
-        markupSection('p', [
-          marker('text before atom'),
-          atom('simple-atom', 'Bob', {}, [markup('strong')]),
-          marker('text after atom')
-        ])
-      ]);
-    }));
+  Helpers.wait(() => {
+    editor.run(postEditor => {
+      let markup = editor.builder.createMarkup('strong');
+      postEditor.addMarkupToRange(editor.range, markup);
+    });
+
+    assert.postIsSimilar(editor.post, Helpers.postAbstract.build(
+      ({post, markupSection, atom, marker, markup}) => {
+        return post([
+          markupSection('p', [
+            marker('text before atom'),
+            atom('simple-atom', 'Bob', {}, [markup('strong')]),
+            marker('text after atom')
+          ])
+        ]);
+      }));
+
+    done();
+  });
 });
 
 test('typing between two atoms inserts character', (assert) => {
@@ -335,7 +343,7 @@ test('typing between two atoms inserts character', (assert) => {
 
     Helpers.dom.insertText(editor, 'A');
 
-    setTimeout(() => {
+    Helpers.wait(() => {
       assert.postIsSimilar(editor.post, expected);
       assert.renderTreeIsEqual(editor._renderTree, expected);
       done();

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -87,7 +87,7 @@ test('editor listeners are quieted for card actions', (assert) => {
   Helpers.dom.selectText(editor ,cardText, editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     // FIXME should have a better assertion here
     assert.ok(true, 'made it here with no javascript errors');
     done();
@@ -113,7 +113,7 @@ test('removing last card from mobiledoc allows additional editing', (assert) => 
 
   button.click();
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.hasNoElement('#editor button:contains(Click me)', 'button is removed');
     assert.hasNoElement('#editor p');
     Helpers.dom.moveCursorTo(editor, $('#editor')[0]);
@@ -213,7 +213,9 @@ test('selecting a card and deleting deletes the card', (assert) => {
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasNoElement('#editor p', 'precond - has no markup section');
 
-  editor.selectSections([editor.post.sections.head]);
+  let range = new Range(editor.post.sections.head.headPosition(),
+                        editor.post.sections.head.tailPosition());
+  editor.selectRange(range);
   Helpers.dom.triggerDelete(editor);
 
   assert.hasNoElement('#my-simple-card', 'has no card after delete');

--- a/tests/acceptance/editor-drag-drop-test.js
+++ b/tests/acceptance/editor-drag-drop-test.js
@@ -20,6 +20,16 @@ function findCenterPointOfTextNode(node) {
 module('Acceptance: editor: drag-drop', {
   beforeEach() {
     editorElement = $('#editor')[0];
+
+    /**
+     * `document.elementFromPoint` return `null` if the element is outside the
+     * viewpor, so force the editor element to in the viewport for this test suite
+     */
+    $(editorElement).css({
+      position: 'fixed',
+      top: '100px',
+      left: '100px'
+    });
   },
   afterEach() {
     if (editor) {

--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -149,7 +149,7 @@ test('can hit enter at end of list item to add new item', (assert) => {
   assert.equal(newLi.text(), '', 'new li has no text');
 
   Helpers.dom.insertText(editor, 'X');
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.hasElement('#editor li:contains(X)', 'text goes in right spot');
 
     const liCount = $('#editor li').length;
@@ -410,7 +410,7 @@ test('selecting empty list items does not cause error', (assert) => {
   Helpers.dom.moveCursorTo(editor, $('#editor li:eq(1)')[0], 0,
                            $('#editor li:eq(2)')[0], 0);
   Helpers.dom.triggerEvent(editor.element, 'click');
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.ok(true, 'no error');
 
     Helpers.dom.insertText(editor, 'X');

--- a/tests/acceptance/editor-post-editor-test.js
+++ b/tests/acceptance/editor-post-editor-test.js
@@ -60,17 +60,17 @@ test('#insertSection inserts after the cursor active section', (assert) => {
 
 test('#insertSection inserts at end when no active cursor section', (assert) => {
   let newSection;
-  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+  editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker}) => {
     newSection = markupSection('p', [marker('123')]);
     return post([
       markupSection('p', [marker('abc')]),
       markupSection('p', [marker('def')])
     ]);
-  });
-  editor = new Editor({mobiledoc});
-  editor.render(editorElement);
+  }, {autofocus: false});
 
   //precond
+  assert.ok(!editor.hasCursor(), 'editor has no cursor');
+  assert.ok(editor.range.isBlank, 'editor has no cursor');
   assert.hasElement('#editor p:eq(0):contains(abc)');
   assert.hasElement('#editor p:eq(1):contains(def)');
   assert.hasNoElement('#editor p:contains(123)');

--- a/tests/acceptance/editor-reparse-test.js
+++ b/tests/acceptance/editor-reparse-test.js
@@ -42,7 +42,7 @@ test('changing text node content causes reparse of section', (assert) => {
 
   node.textContent = 'def';
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.equal(section.text, 'def', 'section reparsed correctly');
     assert.postIsSimilar(editor.post, expected);
     done();
@@ -66,7 +66,7 @@ test('removing text node causes reparse of section', (assert) => {
 
   node.parentNode.removeChild(node);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.equal(section.text, 'def', 'section reparsed correctly');
     assert.postIsSimilar(editor.post, expected);
     done();
@@ -90,7 +90,7 @@ test('removing section node causes reparse of post', (assert) => {
 
   node.parentNode.removeChild(node);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     done();
   });
@@ -115,7 +115,7 @@ test('inserting styled span in section causes section reparse', (assert) => {
   span.appendChild(document.createTextNode('def'));
   node.appendChild(span);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     done();
   });
@@ -137,7 +137,7 @@ test('inserting new top-level node causes reparse of post', (assert) => {
   span.appendChild(document.createTextNode('123'));
   editorElement.appendChild(span);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     done();
   });
@@ -156,7 +156,7 @@ test('inserting node into blank post causes reparse', (assert) => {
   span.appendChild(document.createTextNode('123'));
   editorElement.appendChild(span);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     done();
   });
@@ -183,7 +183,7 @@ test('after reparsing post, mutations still handled properly', (assert) => {
   span.appendChild(document.createTextNode('123'));
   editorElement.appendChild(span);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected1);
 
     let node = editorElement.firstChild.firstChild;
@@ -191,7 +191,7 @@ test('after reparsing post, mutations still handled properly', (assert) => {
 
     node.textContent = 'def';
 
-    setTimeout(() => {
+    Helpers.wait(() => {
       assert.postIsSimilar(editor.post, expected2);
 
       done();
@@ -221,7 +221,7 @@ test('inserting text into text node on left/right of atom is reparsed correctly'
             'precond - correct right cursor node');
 
   rightCursorNode.textContent = 'Z';
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected1);
     assert.renderTreeIsEqual(editor._renderTree, expected1);
 
@@ -230,7 +230,7 @@ test('inserting text into text node on left/right of atom is reparsed correctly'
               'precond - correct left cursor node');
     leftCursorNode.textContent = 'A';
 
-    setTimeout(() => {
+    Helpers.wait(() => {
       assert.postIsSimilar(editor.post, expected2);
       assert.renderTreeIsEqual(editor._renderTree, expected2);
 
@@ -266,8 +266,8 @@ test('mutation inside card element does not cause reparse', (assert) => {
   textNode.textContent = 'adios';
 
   // Allow the mutation observer to fire then...
-  setTimeout(function() {
+  Helpers.wait(function() {
     assert.equal(0, parseCount);
     done();
-  }, 0);
+  });
 });

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -433,7 +433,7 @@ test('when selection incorrectly contains P end tag, editor reports correct sele
                            secondSectionTextNode, 0);
   Helpers.dom.triggerEvent(document, 'mouseup');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.ok(true, 'No error should occur');
 
     let {
@@ -471,7 +471,7 @@ test('when selection incorrectly contains P start tag, editor reports correct se
                            secondSectionPNode, 0);
   Helpers.dom.triggerEvent(document, 'mouseup');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.ok(true, 'No error should occur');
 
     let {
@@ -519,7 +519,7 @@ test('deleting when after deletion there is a trailing space positions cursor at
   let text = 'e';
   Helpers.dom.insertText(editor, text);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.equal(editor.post.sections.head.text, `first ${text}`, 'character is placed after space');
 
     done();
@@ -539,7 +539,7 @@ test('deleting when after deletion there is a leading space positions cursor at 
   let text = 'e';
   Helpers.dom.insertText(editor, text);
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.equal(editor.post.sections.tail.text, `${text} section`, 'correct text after insertion');
     done();
   });

--- a/tests/acceptance/editor-undo-redo-test.js
+++ b/tests/acceptance/editor-undo-redo-test.js
@@ -51,7 +51,7 @@ test('undo/redo the insertion of a character', (assert) => {
 
   Helpers.dom.insertText(editor, 'D');
 
-  setTimeout(()  => {
+  Helpers.wait(()  => {
     assert.postIsSimilar(editor.post, expectedBeforeUndo); // precond
     undo(editor);
     assert.postIsSimilar(editor.post, expectedAfterUndo);
@@ -89,10 +89,10 @@ test('undo/redo the insertion of multiple characters', (assert) => {
 
   Helpers.dom.insertText(editor, 'D');
 
-  setTimeout(()  => {
+  Helpers.wait(()  => {
     Helpers.dom.insertText(editor, 'E');
 
-    setTimeout(()  => {
+    Helpers.wait(()  => {
       assert.postIsSimilar(editor.post, beforeUndo); // precond
 
       undo(editor);
@@ -187,7 +187,7 @@ test('undo insertion of character to a list item', (assert) => {
   Helpers.dom.moveCursorTo(editor, textNode, 'abc'.length);
   Helpers.dom.insertText(editor, 'D');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expectedBeforeUndo); // precond
 
     undo(editor);
@@ -226,10 +226,10 @@ test('undo stack length can be configured (depth 1)', (assert) => {
   Helpers.dom.moveCursorTo(editor, textNode, 'abc'.length);
   Helpers.dom.insertText(editor, 'D');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     Helpers.dom.insertText(editor, 'E');
 
-    setTimeout(() => {
+    Helpers.wait(() => {
       assert.postIsSimilar(editor.post, beforeUndo); // precond
 
       undo(editor);
@@ -243,7 +243,7 @@ test('undo stack length can be configured (depth 1)', (assert) => {
       assert.positionIsEqual(editor.range.head, editor.post.sections.head.tailPosition());
 
       done();
-    }, 0);
+    });
   });
 });
 
@@ -261,10 +261,10 @@ test('undo stack length can be configured (depth 0)', (assert) => {
   Helpers.dom.moveCursorTo(editor, textNode, 'abc'.length);
   Helpers.dom.insertText(editor, 'D');
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     Helpers.dom.insertText(editor, 'E');
 
-    setTimeout(() => {
+    Helpers.wait(() => {
       assert.postIsSimilar(editor.post, beforeUndo); // precond
 
       undo(editor);
@@ -273,7 +273,7 @@ test('undo stack length can be configured (depth 0)', (assert) => {
       assert.positionIsEqual(editor.range.head, editor.post.sections.head.tailPosition());
 
       done();
-    }, 0);
+    });
   });
 });
 
@@ -309,12 +309,12 @@ test('take and undo a snapshot based on drag/dropping of text', (assert) => {
   textNode.textContent = text;
 
   // Allow the mutation observer to fire, then...
-  setTimeout(function() {
+  Helpers.wait(function() {
     assert.postIsSimilar(editor.post, beforeUndo, 'precond - text is added');
     undo(editor);
     assert.postIsSimilar(editor.post, afterUndo, 'text is removed');
     done();
-  }, 0);
+  });
 });
 
 test('take and undo a snapshot when adding a card', (assert) => {

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -73,7 +73,7 @@ function selectText(editor,
   const startOffset = startTextNode.textContent.indexOf(startText),
         endOffset   = endTextNode.textContent.indexOf(endText) + endText.length;
   selectRange(startTextNode, startOffset, endTextNode, endOffset);
-  editor._notifyRangeChange();
+  editor._readRangeFromDOM();
 }
 
 function moveCursorWithoutNotifyingEditorTo(editor, node, offset=0, endNode=node, endOffset=offset) {
@@ -84,7 +84,7 @@ function moveCursorTo(editor, node, offset=0, endNode=node, endOffset=offset) {
   assertEditor(editor);
   if (!node) { throw new Error('Cannot moveCursorTo node without node'); }
   moveCursorWithoutNotifyingEditorTo(editor, node, offset, endNode, endOffset);
-  editor._notifyRangeChange();
+  editor._readRangeFromDOM();
 }
 
 function triggerEvent(node, eventType) {

--- a/tests/helpers/mobiledoc.js
+++ b/tests/helpers/mobiledoc.js
@@ -14,6 +14,7 @@ import { mergeWithOptions } from 'mobiledoc-kit/utils/merge';
  *      ])
  *    })
  *  )
+ *  @return Mobiledoc
  */
 function build(treeFn, version) {
   let post = PostAbstractHelpers.build(treeFn);

--- a/tests/helpers/wait.js
+++ b/tests/helpers/wait.js
@@ -1,0 +1,5 @@
+let wait = (callback) => {
+  window.requestAnimationFrame(callback);
+};
+
+export default wait;

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -5,6 +5,7 @@ import DOMHelpers from './helpers/dom';
 import MobiledocHelpers from './helpers/mobiledoc';
 import PostAbstract from './helpers/post-abstract';
 import { detectIE11 } from './helpers/browsers';
+import wait from './helpers/wait';
 
 const { test:qunitTest, module, skip } = QUnit;
 
@@ -43,5 +44,6 @@ export default {
   postAbstract: PostAbstract,
   test,
   module,
-  skipInIE11
+  skipInIE11,
+  wait
 };

--- a/tests/unit/editor/atom-lifecycle-test.js
+++ b/tests/unit/editor/atom-lifecycle-test.js
@@ -11,7 +11,7 @@ module('Unit: Editor: Atom Lifecycle', {
     editorElement = $('#editor')[0];
   },
   afterEach() {
-    if (editor) {
+    if (editor && !editor.isDestroyed) {
       editor.destroy();
       editor = null;
     }
@@ -258,8 +258,8 @@ test('mutating the content of an atom does not trigger an update', (assert) => {
   $("#the-atom").html("updated");
 
   // ensure the mutations have had time to trigger
-  setTimeout(function(){
+  Helpers.wait(function(){
     assert.ok(!updateTriggered);
     done();
-  }, 10);
+  });
 });

--- a/tests/unit/editor/card-lifecycle-test.js
+++ b/tests/unit/editor/card-lifecycle-test.js
@@ -9,7 +9,7 @@ module('Unit: Editor: Card Lifecycle', {
     editorElement = $('#editor')[0];
   },
   afterEach() {
-    if (editor) {
+    if (editor && !editor.isDestroyed) {
       editor.destroy();
       editor = null;
     }

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -15,8 +15,9 @@ module('Unit: Editor', {
   },
 
   afterEach() {
-    if (editor) {
+    if (editor && !editor.isDestroyed) {
       editor.destroy();
+      editor = null;
     }
   }
 });
@@ -26,6 +27,24 @@ test('can render an editor via dom node reference', (assert) => {
   editor.render(editorElement);
   assert.equal(editor.element, editorElement);
   assert.ok(editor.post);
+});
+
+test('autofocused editor hasCursor and has non-blank range after rendering', (assert) => {
+  let done = assert.async();
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection}) => {
+    return post([markupSection('p')]);
+  });
+  editor = new Editor({autofocus: true, mobiledoc});
+  assert.ok(!editor.hasCursor(), 'precond - editor has no cursor');
+  assert.ok(editor.range.isBlank, 'precond - editor has blank range');
+
+  editor.render(editorElement);
+
+  Helpers.wait(() => {
+    assert.ok(editor.hasCursor(), 'editor has cursor');
+    assert.ok(!editor.range.isBlank, 'editor has non-blank range');
+    done();
+  });
 });
 
 test('creating an editor with DOM node throws', (assert) => {

--- a/tests/unit/editor/post/insert-post-test.js
+++ b/tests/unit/editor/post/insert-post-test.js
@@ -25,7 +25,7 @@ function buildEditorWithMobiledoc(builderFn) {
   let unknownCardHandler = () => {};
   editor = new Editor({mobiledoc, unknownCardHandler});
   editor.render(editorElement);
-  editor.renderRange = function(range) {
+  editor.selectRange = function(range) {
     renderedRange = range;
   };
   return editor;

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -101,7 +101,7 @@ test('editor#parse fixes text in atom headTextNode when atom is at start of sect
   assert.ok(!!headTextNode, 'precond - headTextNode');
   headTextNode.textContent = ZWNJ + 'X';
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
 
@@ -142,7 +142,7 @@ test('editor#parse fixes text in atom headTextNode when atom has marker before i
   assert.ok(!!headTextNode, 'precond - headTextNode');
   headTextNode.textContent = ZWNJ + 'X';
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();
@@ -163,7 +163,7 @@ test('editor#parse fixes text in atom tailTextNode when atom is at end of sectio
   assert.ok(!!tailTextNode, 'precond - tailTextNode');
   tailTextNode.textContent = ZWNJ + 'X';
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();
@@ -184,7 +184,7 @@ test('editor#parse fixes text in atom tailTextNode when atom has atom after it',
   assert.ok(!!tailTextNode, 'precond - tailTextNode');
   tailTextNode.textContent = ZWNJ + 'X';
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();
@@ -206,7 +206,7 @@ test('editor#parse fixes text in atom tailTextNode when atom has marker after it
   assert.ok(!!tailTextNode, 'precond - tailTextNode');
   tailTextNode.textContent = ZWNJ + 'X';
 
-  setTimeout(() => {
+  Helpers.wait(() => {
     assert.postIsSimilar(editor.post, expected);
     assert.renderTreeIsEqual(editor._renderTree, expected);
     done();

--- a/tests/unit/utils/cursor-position-test.js
+++ b/tests/unit/utils/cursor-position-test.js
@@ -13,6 +13,7 @@ module('Unit: Utils: Position', {
   afterEach() {
     if (editor) {
       editor.destroy();
+      editor = null;
     }
   }
 });
@@ -317,4 +318,3 @@ test('Position cannot be on list section', (assert) => {
   position = new Position(listItem, 0);
   assert.ok(position, 'position with list item is ok');
 });
-

--- a/tests/unit/utils/key-test.js
+++ b/tests/unit/utils/key-test.js
@@ -54,23 +54,3 @@ test('firefox arrow keypress is not printable', (assert) => {
   let key = Key.fromEvent(event);
   assert.ok(!key.isPrintable());
 });
-
-test('HOME key is movement', (assert) => {
-  let element = $('#qunit-fixture')[0];
-  let event = Helpers.dom.createMockEvent('keypress', element, {
-    keyCode: Keycodes.HOME,
-    charCode: 0
-  });
-  let key = Key.fromEvent(event);
-  assert.ok(key.isMovement());
-});
-
-test('END key is movement', (assert) => {
-  let element = $('#qunit-fixture')[0];
-  let event = Helpers.dom.createMockEvent('keypress', element, {
-    keyCode: Keycodes.END,
-    charCode: 0
-  });
-  let key = Key.fromEvent(event);
-  assert.ok(key.isMovement());
-});


### PR DESCRIPTION
SelectionChangeObserver maintains a singleton instance that polls the
window using `requestAnimationFrame` for changes to the selection.
Editors' EventManager instances use a SelectionManager to listen for
`selectionchanged` events, and update the editor's `range` if necessary.

Removes code that would use some keyup events (when `key.isMovement()`)
and `mouseup` events to detect when the range could have changed.

The range-detection code was previously spread out over `EventManager`,
`Editor`, `Cursor` and `EditState`. This code change consolidates most
of the responsibility for knowing/reading/updating the editor's `range`
o its `EditState` instance. The editor now delegates `range` to the edit
state instance, and the edit state instance is responsible for knowing
when the editor's inputMode or range has changed.

Some tests assumed selection changes would be picked up synchronously;
for those tests a `Helpers.wait` helper is added that schedules a
callback with `requestAnimationFrame`.

Also:
 * use "hidepassed" for sauce tests to improve test failure debugging


fixes #408 
fixes #383 
related #369 
related #302 
