### PR TITLE
Refocus editor after toggling markup when no selection. fixes #369

### DIFF
--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -116,9 +116,9 @@ const Cursor = class Cursor {
     const { node:headNode, offset:headOffset } = this._findNodeForPosition(head),
           { node:tailNode, offset:tailOffset } = this._findNodeForPosition(tail);
     this._moveToNode(headNode, headOffset, tailNode, tailOffset, direction);
-    if (document.activeElement !== this.editor.element) {
-      this.editor.element.focus();
-    }
+
+    // Firefox sometimes doesn't keep focus in the editor after adding a card
+    this.editor._ensureFocus();
   }
 
   get selection() {

--- a/tests/unit/editor/editor-events-test.js
+++ b/tests/unit/editor/editor-events-test.js
@@ -214,11 +214,13 @@ test('inputModeDidChange callback fired when markup is toggled and there is a se
   });
 });
 
-test('inputModeDidChange callback fired when markup is toggled and there is no selection', (assert) => {
+test('inputModeDidChange callback fired when markup is toggled and selection is collapsed', (assert) => {
   let done = assert.async();
-  assert.expect(1);
+  assert.expect(2);
 
   editor.selectRange(new Range(editor.post.headPosition()));
+
+  assert.ok(editor.range.isCollapsed, 'precond - range is collapsed');
 
   Helpers.wait(() => {
     let inputChanged = 0;
@@ -250,6 +252,35 @@ test('inputModeDidChange callback fired when moving cursor into markup', (assert
 
     Helpers.wait(() => {
       assert.equal(inputChanged, 1, 'inputModeDidChange fired once');
+      done();
+    });
+  });
+});
+
+test('after #toggleMarkup, editor refocuses if it had selection', (assert) => {
+  let done = assert.async();
+  assert.expect(3);
+
+  let button = $('<button>BOLD</button>').appendTo('#qunit-fixture').click(() => {
+    Helpers.dom.selectText(editor, 'this', editorElement); // necessary for Safari to detect a selection in the editor
+    button.focus();
+
+    assert.ok(document.activeElement !== editor.element, 'precond - editor element is not focused');
+    editor.toggleMarkup('b');
+  });
+
+  editor.selectRange(new Range(editor.post.headPosition()));
+
+  Helpers.wait(() => {
+    let inputChanged = 0;
+    editor.inputModeDidChange(() => inputChanged++);
+
+    button.click();
+
+    Helpers.wait(() => {
+      assert.equal(inputChanged, 1, 'inputModeDidChange fired once');
+      assert.ok(document.activeElement === editor.element, 'editor element is focused');
+
       done();
     });
   });


### PR DESCRIPTION
Ensures that we refocus the editor element after `toggleMarkup`.
Clicking a button can cause the button to become focused (e.g.
`document.activeElement === buttonElement`) but the window's
`getSelection` is still in the editor.
When the selection is in the editor but it is not focused, key
up/down/press events don't fire on it. Since it has the selection,
typing causes the browser to mutate the editor element's dom and bypass
the key* event handlers. In addition to being generally unwanted, this has the
downside that the mutation will insert text to match its surrounding
style, so the `toggleMarkup` ends up having no effect.

After this change, it is possible to click e.g. the "bold" button when
the selection is collapsed, and the next characters typed will be bold,
as expected.