### PR TITLE
Add forward/backward inclusivity rules for markups fix #402 fix #392

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -475,8 +475,11 @@ class Editor {
   /**
    * @param {Markup|String} markup A markup instance, or a string (e.g. "b")
    * @return {boolean}
+   * @deprecated after v0.10.1
    */
   hasActiveMarkup(markup) {
+    deprecate(`editor#hasActiveMarkup is deprecated. Use editor#activeMarkups instead`);
+
     let matchesFn;
     if (typeof markup === 'string') {
       markup = markup.toLowerCase();

--- a/src/js/models/markup.js
+++ b/src/js/models/markup.js
@@ -37,6 +37,14 @@ class Markup {
            VALID_MARKUP_TAGNAMES.indexOf(this.tagName) !== -1);
   }
 
+  isForwardInclusive() {
+    return this.tagName === normalizeTagName("a") ? false : true;
+  }
+
+  isBackwardInclusive() {
+    return false;
+  }
+
   hasTag(tagName) {
     return this.tagName === normalizeTagName(tagName);
   }

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -121,9 +121,23 @@ class Post {
     const markups = new Set();
 
     if (range.isCollapsed) {
-      let marker = range.head.marker;
-      if (marker) {
-        marker.markups.forEach(m => markups.add(m));
+      let pos = range.head;
+      if (pos.isMarkerable) {
+        let [back, forward] = [pos.markerIn(-1), pos.markerIn(1)];
+        if (back && forward && back === forward) {
+          back.markups.forEach(m => markups.add(m));
+        } else {
+          (back && back.markups || []).forEach(m => {
+            if (m.isForwardInclusive()) {
+              markups.add(m);
+            }
+          });
+          (forward && forward.markups || []).forEach(m => {
+            if (m.isBackwardInclusive()) {
+              markups.add(m);
+            }
+          });
+        }
       }
     } else {
       this.walkMarkerableSections(range, (section) => {

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -361,25 +361,24 @@ test('#activeMarkups returns the markups at cursor when range is collapsed', (as
 test('#hasActiveMarkup returns true for complex markups', (assert) => {
   editor = Helpers.mobiledoc.renderInto(editorElement, ({post, markupSection, marker, markup}) => {
     return post([markupSection('p', [
-      marker('abc'),
+      marker('abc '),
       marker('def', [markup('a', {href: 'http://bustle.com'})]),
-      marker('ghi')
+      marker(' ghi')
     ])]);
   });
 
   let head = editor.post.sections.head;
-  editor.selectRange(Range.create(head, 'abc'.length));
-  assert.equal(editor.activeMarkups.length, 0, 'no active markups at left of bold text');
+  editor.selectRange(Range.create(head, 'abc '.length));
+  assert.equal(editor.activeMarkups.length, 0, 'no active markups at left of linked text');
 
-  editor.selectRange(Range.create(head, 'abcd'.length));
+  editor.selectRange(Range.create(head, 'abc d'.length));
   assert.equal(editor.activeMarkups.length, 1, 'active markups in linked text');
   assert.ok(editor.hasActiveMarkup('a'), 'has A active markup');
 
-  editor.selectRange(Range.create(head, 'abcdef'.length));
-  assert.equal(editor.activeMarkups.length, 1, 'active markups at end of linked text');
-  assert.ok(editor.hasActiveMarkup('a'), 'has A active markup');
+  editor.selectRange(Range.create(head, 'abc def'.length));
+  assert.equal(editor.activeMarkups.length, 0, 'active markups at end of linked text');
 
-  editor.selectRange(Range.create(head, 'abcdefg'.length));
+  editor.selectRange(Range.create(head, 'abc def '.length));
   assert.equal(editor.activeMarkups.length, 0, 'no active markups after end of linked text');
 });
 

--- a/tests/unit/models/atom-test.js
+++ b/tests/unit/models/atom-test.js
@@ -1,4 +1,5 @@
-const {module, test} = QUnit;
+import Helpers from 'mobiledoc-kit/test-helpers';
+const {module, test} = Helpers;
 
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 

--- a/tests/unit/models/card-test.js
+++ b/tests/unit/models/card-test.js
@@ -1,4 +1,5 @@
-const {module, test} = QUnit;
+import Helpers from 'mobiledoc-kit/test-helpers';
+const {module, test} = Helpers;
 
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -1,4 +1,5 @@
-const {module, test} = QUnit;
+import Helpers from 'mobiledoc-kit/test-helpers';
+const {module, test} = Helpers;
 
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -220,6 +220,33 @@ test('#markupsInRange returns all markups when range is not collapsed', (assert)
   assert.inArray(a2, found, 'finds a2');
 });
 
+test('#markupsInRange obeys left- and right-inclusive rules for "A" markups', (assert) => {
+  let a;
+  let post = Helpers.postAbstract.build(({post, markupSection, marker, markup}) => {
+    a = markup('a', {href: 'example.com'});
+    return post([markupSection('p', [
+      marker('123', [a]),
+      marker(' abc '),
+      marker('def', [a]),
+      marker( ' ghi '),
+      marker( 'jkl', [a])
+    ])]);
+  });
+
+  let section = post.sections.head;
+  let start = Range.create(section, 0);
+  let left = Range.create(section, '123 abc '.length);
+  let inside = Range.create(section, '123 abc d'.length);
+  let right = Range.create(section, '123 abc def'.length);
+  let end = Range.create(section, '123 abc def ghi jkl'.length);
+
+  assert.deepEqual(post.markupsInRange(start), [], 'no markups at start');
+  assert.deepEqual(post.markupsInRange(left), [], 'no markups at left');
+  assert.deepEqual(post.markupsInRange(right), [], 'no markups at right');
+  assert.deepEqual(post.markupsInRange(inside), [a], '"A" markup inside range');
+  assert.deepEqual(post.markupsInRange(end), [], 'no markups at end');
+});
+
 test('#markersContainedByRange when range is single marker', (assert) => {
   let found;
   const post = Helpers.postAbstract.build(({post, marker, markupSection}) => {

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -1,9 +1,9 @@
 import mobiledocParsers from 'mobiledoc-kit/parsers/mobiledoc';
 import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
-import Helpers from '../../test-helpers';
+import Helpers from 'mobiledoc-kit/tests/helpers';
 
-const { module, test } = window.QUnit;
+const { module, test } = Helpers;
 
 let builder, post;
 

--- a/tests/unit/parsers/mobiledoc/0-2-test.js
+++ b/tests/unit/parsers/mobiledoc/0-2-test.js
@@ -3,7 +3,8 @@ import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 
 const DATA_URL = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
-const { module, test } = window.QUnit;
+import Helpers from 'mobiledoc-kit/tests/helpers';
+const { module, test } = Helpers;
 
 let parser, builder, post;
 

--- a/tests/unit/parsers/mobiledoc/0-3-test.js
+++ b/tests/unit/parsers/mobiledoc/0-3-test.js
@@ -3,7 +3,8 @@ import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-3';
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 
 const DATA_URL = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
-const { module, test } = window.QUnit;
+import Helpers from 'mobiledoc-kit/tests/helpers';
+const { module, test } = Helpers;
 
 let parser, builder, post;
 

--- a/tests/unit/utils/linked-list-test.js
+++ b/tests/unit/utils/linked-list-test.js
@@ -1,4 +1,5 @@
-const {module, test} = QUnit;
+import Helpers from '../../test-helpers';
+const {module, test} = Helpers;
 
 import LinkedList from 'mobiledoc-kit/utils/linked-list';
 import LinkedItem from 'mobiledoc-kit/utils/linked-item';


### PR DESCRIPTION
Changes `Post#markupsInRange` to check the markers to the left and right
of the position when range is collapsed. The markups in those markers
provide `isForwardInclusive` and `isBackwardInclusive` methods that are
used to determine which markups should be considered "active" at that
range.

fix #392
fix #402