### PR TITLE
Un-deprecate editor#hasActiveMarkups, remove editor#markupsInSelection

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -10,7 +10,7 @@ import RenderTree from 'mobiledoc-kit/models/render-tree';
 import mobiledocRenderers from '../renderers/mobiledoc';
 import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
 import { mergeWithOptions } from '../utils/merge';
-import { clearChildNodes, addClassName } from '../utils/dom-utils';
+import { normalizeTagName, clearChildNodes, addClassName } from '../utils/dom-utils';
 import { forEach, filter, contains, values } from '../utils/array-utils';
 import { setData } from '../utils/element-utils';
 import Cursor from '../utils/cursor';
@@ -24,7 +24,6 @@ import {
 import { CARD_MODES } from '../models/card';
 import { detect } from '../utils/array-utils';
 import assert from '../utils/assert';
-import deprecate from '../utils/deprecate';
 import MutationHandler from 'mobiledoc-kit/editor/mutation-handler';
 import EditHistory from 'mobiledoc-kit/editor/edit-history';
 import EventManager from 'mobiledoc-kit/editor/event-manager';
@@ -473,6 +472,7 @@ class Editor {
 
   /**
    * @type {Markup[]}
+   * @public
    */
   get activeMarkups() {
     return this._editState.activeMarkups;
@@ -481,25 +481,17 @@ class Editor {
   /**
    * @param {Markup|String} markup A markup instance, or a string (e.g. "b")
    * @return {boolean}
-   * @deprecated after v0.10.1
    */
   hasActiveMarkup(markup) {
-    deprecate(`editor#hasActiveMarkup is deprecated. Use editor#activeMarkups instead`);
-
     let matchesFn;
     if (typeof markup === 'string') {
-      markup = markup.toLowerCase();
-      matchesFn = (_markup) => _markup.tagName === markup;
+      let tagName = normalizeTagName(markup);
+      matchesFn = (m) => m.tagName === tagName;
     } else {
-      matchesFn = (_markup) => _markup === markup;
+      matchesFn = (m) => m === markup;
     }
 
     return !!detect(this.activeMarkups, matchesFn);
-  }
-
-  get markupsInSelection() {
-    // FIXME deprecate this
-    return this.activeMarkups;
   }
 
   /**

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -482,7 +482,7 @@ test('selecting text that touches bold text should not be considered bold', (ass
   Helpers.dom.triggerEvent(document, 'mouseup');
 
   let bold = editor.builder.createMarkup('strong');
-  assert.ok(editor.markupsInSelection.indexOf(bold) === -1, 'strong is not in selection');
+  assert.ok(editor.activeMarkups.indexOf(bold) === -1, 'strong is not in selection');
 });
 
 // https://github.com/bustlelabs/mobiledoc-kit/issues/121
@@ -503,7 +503,7 @@ test('selecting text that includes a 1-character marker and unbolding it', (asse
   Helpers.dom.selectText(editor ,'b', editorElement, 'c', editorElement);
 
   let bold = editor.builder.createMarkup('strong');
-  assert.ok(editor.markupsInSelection.indexOf(bold) !== -1, 'strong is in selection');
+  assert.ok(editor.activeMarkups.indexOf(bold) !== -1, 'strong is in selection');
 
   editor.run(postEditor => postEditor.toggleMarkup('strong'));
 
@@ -535,7 +535,7 @@ test('selecting text that includes an empty section and applying markup to it', 
   assert.hasElement('#editor p strong:contains(abc)', 'bold is applied to text');
 });
 
-test('placing cursor inside a strong section should cause markupsInSelection to contain "strong"', (assert) => {
+test('placing cursor inside a strong section should cause activeMarkups to contain "strong"', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker, markup}) => {
     const b = markup('strong');
     return post([markupSection('p', [
@@ -550,10 +550,10 @@ test('placing cursor inside a strong section should cause markupsInSelection to 
   Helpers.dom.moveCursorTo(editor, $('#editor strong')[0].firstChild, 1);
 
   let bold = editor.builder.createMarkup('strong');
-  assert.ok(editor.markupsInSelection.indexOf(bold) !== -1, 'strong is in selection');
+  assert.ok(editor.activeMarkups.indexOf(bold) !== -1, 'strong is in selection');
 
   Helpers.dom.moveCursorTo(editor, $('#editor')[0].childNodes[0], 1);
   delete editor._activeMarkups;
 
-  assert.ok(editor.markupsInSelection.indexOf(bold) === -1, 'strong is not in selection');
+  assert.ok(editor.activeMarkups.indexOf(bold) === -1, 'strong is not in selection');
 });


### PR DESCRIPTION
Mark `editor#activeMarkups` as public