### PR TITLE
Refactor `deleteRange`

### DIFF
--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -304,7 +304,7 @@ test('forward-delete in empty li with li after it joins with li', (assert) => {
   assert.hasElement('#editor li:contains(Xabc)', 'inserts text at right spot');
 });
 
-test('forward-delete in empty li with markup section after it deletes li', (assert) => {
+test('forward-delete in empty li with markup section after it joins markup section', (assert) => {
    const mobiledoc = Helpers.mobiledoc.build(builder => {
     const {post, listSection, listItem, markupSection, marker} = builder;
     return post([
@@ -319,13 +319,12 @@ test('forward-delete in empty li with markup section after it deletes li', (asse
   Helpers.dom.moveCursorTo(editor, node, 0);
   Helpers.dom.triggerForwardDelete(editor);
 
-  assert.hasNoElement('#editor li', 'li is removed');
-  assert.hasElement('#editor p:contains(abc)', 'p remains');
+  assert.hasElement('#editor li:contains(abc)', 'joins markup section');
+  assert.hasNoElement('#editor p', 'p is removed');
 
   Helpers.dom.insertText(editor, 'X');
 
-  assert.hasElement('#editor p:contains(Xabc)', 'inserts text at right spot');
- 
+  assert.hasElement('#editor li:contains(Xabc)', 'inserts text at right spot');
 });
 
 test('forward-delete end of li with nothing after', (assert) => {

--- a/tests/unit/editor/post-delete-at-position-test.js
+++ b/tests/unit/editor/post-delete-at-position-test.js
@@ -7,6 +7,7 @@ const { FORWARD, BACKWARD } = DIRECTION;
 const { module, test } = Helpers;
 
 let { postEditor: { run } } = Helpers;
+let { postAbstract: { buildFromText } } = Helpers;
 
 module('Unit: PostEditor: #deleteAtPosition');
 
@@ -24,8 +25,8 @@ test('single markup section (backward)', (assert) => {
   ];
 
   examples.forEach(([before, after, msg]) => {
-    let { post, range: { head: position } } = Helpers.postAbstract.buildFromText(before);
-    let { post: expectedPost, range: { head: expectedPosition } } = Helpers.postAbstract.buildFromText(after);
+    let { post, range: { head: position } } = buildFromText(before);
+    let { post: expectedPost, range: { head: expectedPosition } } = buildFromText(after);
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, BACKWARD));
 
@@ -50,8 +51,8 @@ test('single markup section (forward)', (assert) => {
   ];
 
   examples.forEach(([before, after, msg]) => {
-    let { post, range: { head: position } } = Helpers.postAbstract.buildFromText(before);
-    let { post: expectedPost, range: { head: expectedPosition } } = Helpers.postAbstract.buildFromText(after);
+    let { post, range: { head: position } } = buildFromText(before);
+    let { post: expectedPost, range: { head: expectedPosition } } = buildFromText(after);
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, FORWARD));
 
@@ -72,8 +73,8 @@ test('across section boundary (backward)', (assert) => {
   ];
 
   examples.forEach(([before, after, msg]) => {
-    let { post, range: { head: position } } = Helpers.postAbstract.buildFromText(before);
-    let { post: expectedPost, range: { head: expectedPosition } } = Helpers.postAbstract.buildFromText(after);
+    let { post, range: { head: position } } = buildFromText(before);
+    let { post: expectedPost, range: { head: expectedPosition } } = buildFromText(after);
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, BACKWARD));
 
@@ -94,8 +95,8 @@ test('across section boundary (forward)', (assert) => {
   ];
 
   examples.forEach(([before, after, msg]) => {
-    let { post, range: { head: position } } = Helpers.postAbstract.buildFromText(before);
-    let { post: expectedPost, range: { head: expectedPosition } } = Helpers.postAbstract.buildFromText(after);
+    let { post, range: { head: position } } = buildFromText(before);
+    let { post: expectedPost, range: { head: expectedPosition } } = buildFromText(after);
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, FORWARD));
 
@@ -114,8 +115,8 @@ test('across list item boundary (backward)', (assert) => {
   ];
 
   examples.forEach(([before, after, msg]) => {
-    let { post, range: { head: position } } = Helpers.postAbstract.buildFromText(before);
-    let { post: expectedPost, range: { head: expectedPosition } } = Helpers.postAbstract.buildFromText(after);
+    let { post, range: { head: position } } = buildFromText(before);
+    let { post: expectedPost, range: { head: expectedPosition } } = buildFromText(after);
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, BACKWARD));
 
@@ -148,8 +149,8 @@ test('across list item boundary (forward)', (assert) => {
   ];
 
   examples.forEach(([before, after, msg]) => {
-    let { post, range: { head: position } } = Helpers.postAbstract.buildFromText(before);
-    let { post: expectedPost, range: { head: expectedPosition } } = Helpers.postAbstract.buildFromText(after);
+    let { post, range: { head: position } } = buildFromText(before);
+    let { post: expectedPost, range: { head: expectedPosition } } = buildFromText(after);
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, FORWARD));
 

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -44,80 +44,6 @@ module('Unit: PostEditor', {
   }
 });
 
-test('#cutSection with one marker', (assert) => {
-  let post, section;
-  Helpers.postAbstract.build(({marker, markupSection, post: buildPost}) => {
-    section = markupSection('p', [ marker('abc') ]);
-    post = buildPost([ section ]);
-  });
-
-  renderBuiltAbstract(post, mockEditor);
-  postEditor.cutSection(section, 1, 2);
-  postEditor.complete();
-
-  assert.equal(post.sections.head.text, 'ac');
-  assert.equal(post.sections.length, 1, 'only 1 section remains');
-  assert.equal(post.sections.head.markers.length, 1, 'markers are joined');
-});
-
-test('#cutSection at boundaries across markers', (assert) => {
-  let post, section;
-  Helpers.postAbstract.build(({marker, markupSection, post: buildPost}) => {
-    const markers = "abcd".split('').map(l => marker(l));
-    section = markupSection('p', markers);
-    post = buildPost([section]);
-  });
-
-  renderBuiltAbstract(post, mockEditor);
-  assert.equal(post.sections.head.text, 'abcd'); //precond
-  assert.equal(post.sections.head.markers.length, 4); //precond
-  postEditor.cutSection(section, 1, 3);
-  postEditor.complete();
-
-  assert.equal(post.sections.head.text, 'ad');
-  assert.equal(post.sections.length, 1, 'only 1 section remains');
-  assert.equal(post.sections.head.markers.length, 1, 'markers are joined');
-});
-
-test('#cutSection in head marker', (assert) => {
-  let post, section;
-  Helpers.postAbstract.build(({marker, markupSection, post: buildPost}) => {
-    section = markupSection('p', [marker('a'), marker('bc')]);
-    post = buildPost([ section ]);
-  });
-
-  renderBuiltAbstract(post, mockEditor);
-  assert.equal(section.text, 'abc'); //precond
-  assert.equal(section.markers.length, 2); //precond
-  postEditor.cutSection(section, 2, 3);
-  postEditor.complete();
-
-  assert.equal(post.sections.head.text, 'ab');
-  assert.equal(post.sections.length, 1, 'only 1 section remains');
-  assert.equal(post.sections.head.markers.length, 1, 'markers are joined');
-});
-
-test('#cutSection in tail marker', (assert) => {
-  let post, section;
-  Helpers.postAbstract.build(({marker, markupSection, post: buildPost}) => {
-    section = markupSection('p', [
-      marker('a'),
-      marker('bc')
-    ]);
-    post = buildPost([ section ]);
-  });
-
-  renderBuiltAbstract(post, mockEditor);
-
-  postEditor.cutSection(section, 0, 2);
-
-  postEditor.complete();
-
-  assert.equal(post.sections.head.text, 'c');
-  assert.equal(post.sections.length, 1, 'only 1 section remains');
-  assert.equal(post.sections.head.markers.length, 1, 'two markers remain');
-});
-
 test('#splitMarkers when headMarker = tailMarker', (assert) => {
   let post, section;
   Helpers.postAbstract.build(({marker, markupSection, post: buildPost}) => {
@@ -405,7 +331,7 @@ test('neighboring atoms do not get coalesced', (assert) => {
   assert.ok(!section.markers.tail.hasMarkup(strong));
 });
 
-test('#removeMarkupFromRange silently does nothing when invoked with an empty range', (assert) => {
+test('#removeMarkupFromRange is no-op with collapsed range', (assert) => {
   let section, markup;
   const post = Helpers.postAbstract.build(({
     post, markupSection, marker, markup: buildMarkup
@@ -486,7 +412,7 @@ test('#removeMarkupFromRange handles atoms correctly', (assert) => {
   assert.ok(!tail.hasMarkup(bold), 'tail has no bold');
 });
 
-test('#addMarkupToRange silently does nothing when invoked with an empty range', (assert) => {
+test('#addMarkupToRange is no-op with collapsed range', (assert) => {
   let section, markup;
   const post = Helpers.postAbstract.build(({
     post, markupSection, marker, markup: buildMarkup


### PR DESCRIPTION
Also refactor `cutSection`, change it to accept positions rather than
offsets.
Remove `splitMarker` (now-unused).

Fix one incorrect acceptance test for list items.
Add more unit tests for `deleteRange`.

Follow-up to #442