### PR TITLE
Add `toRange` and `toPosition` methods to Position, Section, Post

### DIFF
--- a/src/js/editor/edit-history.js
+++ b/src/js/editor/edit-history.js
@@ -1,6 +1,4 @@
 import mobiledocParsers from 'mobiledoc-kit/parsers/mobiledoc';
-import Range from 'mobiledoc-kit/utils/cursor/range';
-import Position from 'mobiledoc-kit/utils/cursor/position';
 import FixedQueue from 'mobiledoc-kit/utils/fixed-queue';
 
 function findLeafSectionAtIndex(post, index) {
@@ -40,8 +38,10 @@ export class Snapshot {
       let headSection = findLeafSectionAtIndex(post, headLeafSectionIndex);
       let tailSection = findLeafSectionAtIndex(post, tailLeafSectionIndex);
 
-      return new Range(new Position(headSection, headOffset),
-                       new Position(tailSection, tailOffset));
+      head = headSection.toPosition(headOffset);
+      tail = tailSection.toPosition(tailOffset);
+
+      return head.toRange(tail);
     }
   }
 }

--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -4,7 +4,6 @@ import {
   setClipboardData,
   parsePostFromDrop
 } from 'mobiledoc-kit/utils/parse-utils';
-import Range from 'mobiledoc-kit/utils/cursor/range';
 import { filter, forEach } from 'mobiledoc-kit/utils/array-utils';
 import Key from 'mobiledoc-kit/utils/key';
 import { TAB } from 'mobiledoc-kit/utils/characters';
@@ -224,7 +223,7 @@ export default class EventManager {
 
     editor.run(postEditor => {
       let nextPosition = postEditor.insertPost(position, pastedPost);
-      postEditor.setRange(new Range(nextPosition));
+      postEditor.setRange(nextPosition);
     });
   }
 
@@ -248,7 +247,7 @@ export default class EventManager {
 
     editor.run(postEditor => {
       let nextPosition = postEditor.insertPost(position, post);
-      postEditor.setRange(new Range(nextPosition));
+      postEditor.setRange(nextPosition);
     });
   }
 

--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -2,20 +2,18 @@ import Key from '../utils/key';
 import { MODIFIERS, SPECIAL_KEYS } from '../utils/key';
 import { filter, reduce } from '../utils/array-utils';
 import assert from '../utils/assert';
-import Range from '../utils/cursor/range';
 import Browser from '../utils/browser';
 
 function selectAll(editor) {
   let { post } = editor;
-  let allRange = new Range(post.headPosition(), post.tailPosition());
-  editor.selectRange(allRange);
+  editor.selectRange(post.toRange());
 }
 
 function gotoStartOfLine(editor) {
   let {range} = editor;
   let {tail: {section}} = range;
   editor.run(postEditor => {
-    postEditor.setRange(new Range(section.headPosition()));
+    postEditor.setRange(section.headPosition());
   });
 }
 
@@ -23,7 +21,7 @@ function gotoEndOfLine(editor) {
   let {range} = editor;
   let {tail: {section}} = range;
   editor.run(postEditor => {
-    postEditor.setRange(new Range(section.tailPosition()));
+    postEditor.setRange(section.tailPosition());
   });
 }
 
@@ -52,11 +50,12 @@ export const DEFAULT_KEY_COMMANDS = [{
   run(editor) {
     let { range } = editor;
     if (range.isCollapsed) {
-      range = new Range(range.head, range.head.section.tailPosition());
+      let { head, head: { section } } = range;
+      range = head.toRange(section.tailPosition());
     }
     editor.run(postEditor => {
       let nextPosition = postEditor.deleteRange(range);
-      postEditor.setRange(new Range(nextPosition));
+      postEditor.setRange(nextPosition);
     });
   }
 }, {

--- a/src/js/editor/post/post-inserter.js
+++ b/src/js/editor/post/post-inserter.js
@@ -7,7 +7,6 @@ import {
   IMAGE_SECTION_TYPE,
   LIST_ITEM_TYPE,
 } from 'mobiledoc-kit/models/types';
-import Range from 'mobiledoc-kit/utils/cursor/range';
 
 const MARKERABLE = 'markerable',
       NESTED_MARKERABLE = 'nested_markerable',
@@ -30,7 +29,7 @@ class Visitor {
 
   set cursorPosition(position) {
     this._cursorPosition = position;
-    this.postEditor.setRange(new Range(position));
+    this.postEditor.setRange(position);
   }
 
   visit(node) {

--- a/src/js/editor/text-input-handlers.js
+++ b/src/js/editor/text-input-handlers.js
@@ -1,5 +1,3 @@
-import Range from 'mobiledoc-kit/utils/cursor/range';
-
 /**
  * Convert section at the editor's cursor position into a list.
  * Does nothing if the cursor position is not at the start of the section,
@@ -26,7 +24,7 @@ export function replaceWithListSection(editor, listTagName) {
     let listSection = builder.createListSection(listTagName, [item]);
 
     postEditor.replaceSection(section, listSection);
-    postEditor.setRange(new Range(listSection.headPosition()));
+    postEditor.setRange(listSection.headPosition());
   });
 }
 
@@ -49,7 +47,7 @@ export function replaceWithHeaderSection(editor, headingTagName) {
     let { builder } = postEditor;
     let newSection = builder.createMarkupSection(headingTagName);
     postEditor.replaceSection(section, newSection);
-    postEditor.setRange(new Range(newSection.headPosition()));
+    postEditor.setRange(newSection.headPosition());
   });
 }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,7 @@
 import Editor from './editor/editor';
 import ImageCard from './cards/image';
 import Range from './utils/cursor/range';
+import Position from './utils/cursor/position';
 import Error from './utils/mobiledoc-error';
 import VERSION from './version';
 
@@ -8,6 +9,7 @@ const Mobiledoc = {
   Editor,
   ImageCard,
   Range,
+  Position,
   Error,
   VERSION
 };

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -35,6 +35,10 @@ export default class Section extends LinkedItem {
     unimplementedMethod('isValidTagName', this);
   }
 
+  get length() {
+    return 0;
+  }
+
   get isBlank() {
     unimplementedMethod('isBlank', this);
   }
@@ -47,14 +51,40 @@ export default class Section extends LinkedItem {
     unimplementedMethod('canJoin', this);
   }
 
+  /**
+   * @return {Position} The position at the start of this section
+   * @public
+   */
   headPosition() {
-    return new Position(this, 0);
+    return this.toPosition(0);
   }
 
+  /**
+   * @return {Position} The position at the end of this section
+   * @public
+   */
   tailPosition() {
-    assert('Cannot determine tailPosition without length',
-           this.length !== undefined && this.length !== null);
-    return new Position(this, this.length);
+    return this.toPosition(this.length);
+  }
+
+  /**
+   * @param {Number} offset
+   * @return {Position} The position in this section at the given offset
+   * @public
+   */
+  toPosition(offset) {
+    assert("Must pass number to `toPosition`", typeof offset === 'number');
+    assert("Cannot call `toPosition` with offset > length", offset <= this.length);
+
+    return new Position(this, offset);
+  }
+
+  /**
+   * @return {Range} A range from this section's head to tail positions
+   * @public
+   */
+  toRange() {
+    return this.headPosition().toRange(this.tailPosition());
   }
 
   join() {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -2,7 +2,6 @@ import { POST_TYPE } from './types';
 import LinkedList from 'mobiledoc-kit/utils/linked-list';
 import { forEach, compact } from 'mobiledoc-kit/utils/array-utils';
 import Set from 'mobiledoc-kit/utils/set';
-import Range from 'mobiledoc-kit/utils/cursor/range';
 import Position from 'mobiledoc-kit/utils/cursor/position';
 
 /**
@@ -25,6 +24,11 @@ class Post {
     });
   }
 
+  /**
+   * @return {Position} The position at the start of the post (will be a {@link BlankPosition}
+   * if the post is blank)
+   * @public
+   */
   headPosition() {
     if (this.isBlank) {
       return Position.blankPosition();
@@ -33,12 +37,25 @@ class Post {
     }
   }
 
+  /**
+   * @return {Position} The position at the end of the post (will be a {@link BlankPosition}
+   * if the post is blank)
+   * @public
+   */
   tailPosition() {
     if (this.isBlank) {
       return Position.blankPosition();
     } else {
       return this.sections.tail.tailPosition();
     }
+  }
+
+  /**
+   * @return {Range} A range encompassing the entire post
+   * @public
+   */
+  toRange() {
+    return this.headPosition().toRange(this.tailPosition());
   }
 
   get isBlank() {
@@ -150,8 +167,7 @@ class Post {
   }
 
   walkAllLeafSections(callback) {
-    let range = new Range(this.sections.head.headPosition(),
-                          this.sections.tail.tailPosition());
+    let range = this.headPosition().toRange(this.tailPosition());
     return this.walkLeafSections(range, callback);
   }
 

--- a/src/js/parsers/mobiledoc/0-3.js
+++ b/src/js/parsers/mobiledoc/0-3.js
@@ -33,7 +33,7 @@ export default class MobiledocParser {
 
       return post;
     } catch (e) {
-      throw new Error(`Unable to parse mobiledoc: ${e.message}`);
+      assert(`Unable to parse mobiledoc: ${e.message}`, false);
     }
   }
 

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -44,10 +44,6 @@ class Range {
     );
   }
 
-  static fromSection(section) {
-    return new Range(section.headPosition(), section.tailPosition());
-  }
-
   static blankRange() {
     return new Range(Position.blankPosition(), Position.blankPosition());
   }

--- a/src/js/utils/to-range.js
+++ b/src/js/utils/to-range.js
@@ -1,0 +1,15 @@
+import Range from 'mobiledoc-kit/utils/cursor/range';
+import Position from 'mobiledoc-kit/utils/cursor/position';
+import assert from 'mobiledoc-kit/utils/assert';
+
+export default function toRange(rangeLike) {
+  assert(`Must pass non-blank object to "toRange"`, !!rangeLike);
+
+  if (rangeLike instanceof Range) {
+    return rangeLike;
+  } else if (rangeLike instanceof Position) {
+    return rangeLike.toRange();
+  }
+
+  assert(`Incorrect structure for rangeLike: ${rangeLike}`, false);
+}

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -1,7 +1,5 @@
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
-import Range from 'mobiledoc-kit/utils/cursor/range';
-import Position from 'mobiledoc-kit/utils/cursor/position';
 import { TAB, ENTER } from 'mobiledoc-kit/utils/characters';
 
 const { test, module } = Helpers;
@@ -187,7 +185,7 @@ test('select-all and type text works ok', (assert) => {
 
   Helpers.dom.moveCursorTo(editor, editorElement.firstChild, 0);
   let post = editor.post;
-  editor.selectRange(new Range(post.headPosition(), post.tailPosition()));
+  editor.selectRange(post.toRange());
 
   assert.selectedText('abc', 'precond - abc is selected');
   assert.hasElement('#editor p:contains(abc)', 'precond - renders p');
@@ -230,7 +228,7 @@ test('typing enter splits lines, sets cursor', (assert) => {
       ]);
     });
     assert.postIsSimilar(editor.post, expectedPost, 'correctly encoded');
-    let expectedRange = new Range(new Position(editor.post.sections.tail, 0));
+    let expectedRange = editor.post.sections.tail.headPosition().toRange();
     assert.ok(expectedRange.isEqual(editor.range), 'range is at start of new section');
     done();
   });

--- a/tests/acceptance/cursor-movement-test.js
+++ b/tests/acceptance/cursor-movement-test.js
@@ -2,7 +2,6 @@ import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
 import { MODIFIERS } from 'mobiledoc-kit/utils/key';
 import { supportsSelectionExtend } from '../helpers/browsers';
-import Range from 'mobiledoc-kit/utils/cursor/range';
 
 const { test, module } = Helpers;
 
@@ -339,12 +338,12 @@ test('left/right arrows moves cursor l-to-r and r-to-l across atom', (assert) =>
     return post([markupSection('p', [atom('my-atom', 'first')])]);
   }, editorOptions);
 
-  editor.selectRange(new Range(editor.post.tailPosition()));
+  editor.selectRange(editor.post.tailPosition());
   Helpers.dom.triggerLeftArrowKey(editor);
   assert.positionIsEqual(editor.range.head, editor.post.headPosition());
   assert.positionIsEqual(editor.range.tail, editor.post.headPosition());
 
-  editor.selectRange(new Range(editor.post.headPosition()));
+  editor.selectRange(editor.post.headPosition());
   Helpers.dom.triggerRightArrowKey(editor);
   assert.positionIsEqual(editor.range.head, editor.post.tailPosition());
   assert.positionIsEqual(editor.range.tail, editor.post.tailPosition());
@@ -358,7 +357,7 @@ test('left arrow at start atom moves to end of prev section', (assert) => {
     ]);
   }, editorOptions);
 
-  editor.selectRange(new Range(editor.post.sections.tail.headPosition()));
+  editor.selectRange(editor.post.sections.tail.headPosition());
   Helpers.dom.triggerLeftArrowKey(editor);
   assert.positionIsEqual(editor.range.head, editor.post.sections.head.tailPosition());
 });
@@ -371,7 +370,7 @@ test('right arrow at end of end atom moves to start of next section', (assert) =
     ]);
   }, editorOptions);
 
-  editor.selectRange(new Range(editor.post.sections.head.tailPosition()));
+  editor.selectRange(editor.post.sections.head.tailPosition());
   Helpers.dom.triggerRightArrowKey(editor);
   assert.positionIsEqual(editor.range.head, editor.post.sections.tail.headPosition());
 });
@@ -585,12 +584,12 @@ if (supportsSelectionExtend()) {
       return post([markupSection('p', [atom('my-atom', 'first')])]);
     }, editorOptions);
 
-    editor.selectRange(new Range(editor.post.tailPosition()));
+    editor.selectRange(editor.post.tailPosition());
     Helpers.dom.triggerLeftArrowKey(editor, MODIFIERS.SHIFT);
     assert.positionIsEqual(editor.range.head, editor.post.headPosition());
     assert.positionIsEqual(editor.range.tail, editor.post.tailPosition());
 
-    editor.selectRange(new Range(editor.post.headPosition()));
+    editor.selectRange(editor.post.headPosition());
     Helpers.dom.triggerRightArrowKey(editor, MODIFIERS.SHIFT);
     assert.positionIsEqual(editor.range.head, editor.post.headPosition());
     assert.positionIsEqual(editor.range.tail, editor.post.tailPosition());

--- a/tests/acceptance/cursor-position-test.js
+++ b/tests/acceptance/cursor-position-test.js
@@ -1,6 +1,5 @@
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
-import Position from 'mobiledoc-kit/utils/cursor/position';
 
 const { test, module } = Helpers;
 
@@ -72,8 +71,7 @@ test('cursor moved left from section after card is reported as on the card with 
   Helpers.dom.moveCursorTo(editor, editorElement.firstChild.lastChild, 1);
   let { range } = editor;
 
-  assert.positionIsEqual(range.head,
-                         new Position(editor.post.sections.head, 1));
+  assert.positionIsEqual(range.head, editor.post.sections.head.toPosition(1));
 });
 
 test('cursor moved up from end of section after card is reported as on the card with offset 1', (assert) => {
@@ -198,7 +196,7 @@ test('when at the head of an atom', assert => {
   Helpers.dom.moveCursorTo(editor, atomWrapper.firstChild, 0);
   let range = editor.range;
 
-  let positionBeforeAtom = new Position(editor.post.sections.head, 'aa'.length);
+  let positionBeforeAtom = editor.post.sections.head.toPosition('aa'.length);
 
   assert.positionIsEqual(range.head, positionBeforeAtom);
 
@@ -235,7 +233,7 @@ test('when at the tail of an atom', assert => {
   editor.render(editorElement);
 
   let atomWrapper = editor.post.sections.head.markers.objectAt(1).renderNode.element;
-  let positionAfterAtom = new Position(editor.post.sections.head, 'aa'.length + 1);
+  let positionAfterAtom = editor.post.sections.head.toPosition('aa'.length + 1);
 
   // Before zwnj
   //

--- a/tests/acceptance/editor-atoms-test.js
+++ b/tests/acceptance/editor-atoms-test.js
@@ -56,7 +56,7 @@ test('keystroke of character before starting atom inserts character', (assert) =
     return post([markupSection('p', [atom('simple-atom', 'first')])]);
   }, editorOptions);
 
-  editor.selectRange(new Range(editor.post.headPosition()));
+  editor.selectRange(editor.post.headPosition());
   Helpers.dom.insertText(editor, 'A');
 
   Helpers.wait(() => {
@@ -251,7 +251,7 @@ test('keystroke of enter at markup section head before atom creates new section'
   }, editorOptions);
 
   editor.run(postEditor => {
-    postEditor.setRange(new Range(editor.post.headPosition()));
+    postEditor.setRange(editor.post.headPosition());
   });
   Helpers.dom.triggerEnter(editor);
 
@@ -276,7 +276,7 @@ test('keystroke of enter at list item head before atom creates new section', (as
   }, editorOptions);
 
   editor.run(postEditor => {
-    postEditor.setRange(new Range(editor.post.headPosition()));
+    postEditor.setRange(editor.post.headPosition());
   });
   Helpers.dom.triggerEnter(editor);
 

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -213,9 +213,7 @@ test('selecting a card and deleting deletes the card', (assert) => {
   assert.hasElement('#my-simple-card', 'precond - renders card');
   assert.hasNoElement('#editor p', 'precond - has no markup section');
 
-  let range = new Range(editor.post.sections.head.headPosition(),
-                        editor.post.sections.head.tailPosition());
-  editor.selectRange(range);
+  editor.selectRange(editor.post.sections.head.toRange());
   Helpers.dom.triggerDelete(editor);
 
   assert.hasNoElement('#my-simple-card', 'has no card after delete');

--- a/tests/acceptance/editor-copy-paste-test.js
+++ b/tests/acceptance/editor-copy-paste-test.js
@@ -1,6 +1,5 @@
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../test-helpers';
-import Range from 'mobiledoc-kit/utils/cursor/range';
 import {
   MIME_TEXT_PLAIN,
   MIME_TEXT_HTML
@@ -336,13 +335,13 @@ test('pasting when cursor is on left/right side of card adds content before/afte
   assert.ok(card.isCardSection, 'precond - get card');
 
   Helpers.dom.setCopyData(MIME_TEXT_PLAIN, 'abc');
-  editor.selectRange(new Range(card.headPosition()));
+  editor.selectRange(card.headPosition());
   Helpers.dom.triggerPasteEvent(editor);
 
   assert.postIsSimilar(editor.post, expected1, 'content pasted before card');
 
   Helpers.dom.setCopyData(MIME_TEXT_PLAIN, '123');
-  editor.selectRange(new Range(card.tailPosition()));
+  editor.selectRange(card.tailPosition());
   Helpers.dom.triggerPasteEvent(editor);
 
   assert.postIsSimilar(editor.post, expected2, 'content pasted after card');
@@ -390,9 +389,9 @@ test('paste with shift key pastes plain text', (assert) => {
     ]);
   });
 
-  editor.selectRange(new Range(editor.post.headPosition(), editor.post.tailPosition()));
+  editor.selectRange(editor.post.toRange());
   Helpers.dom.triggerCopyEvent(editor);
-  editor.selectRange(new Range(editor.post.tailPosition()));
+  editor.selectRange(editor.post.tailPosition());
 
   Helpers.dom.triggerKeyEvent(editor, 'keydown', { keyCode: Keycodes.SHIFT });
   Helpers.dom.triggerPasteEvent(editor);

--- a/tests/acceptance/editor-input-handlers-test.js
+++ b/tests/acceptance/editor-input-handlers-test.js
@@ -8,7 +8,7 @@ let editor, editorElement;
 
 function renderEditor(...args) {
   editor = Helpers.mobiledoc.renderInto(editorElement, ...args);
-  editor.selectRange(new Range(editor.post.tailPosition()));
+  editor.selectRange(editor.post.tailPosition());
   return editor;
 }
 
@@ -111,7 +111,7 @@ test('typing "* " at start of markup section does not remove it', (assert) => {
 
   let position = editor.post.sections.head.headPosition();
   position.offset = 1;
-  editor.selectRange(new Range(position));
+  editor.selectRange(position);
 
   Helpers.dom.insertText(editor, ' ');
   assert.hasElement('#editor p:contains(* abc)', 'p is still there');
@@ -122,7 +122,7 @@ test('typing "* " inside of a list section does not create a new list section', 
     return post([listSection('ul', [listItem([marker('*')])])]);
   });
   let position = editor.post.sections.head.items.head.tailPosition();
-  editor.selectRange(new Range(position));
+  editor.selectRange(position);
 
   assert.hasElement('#editor ul > li:contains(*)', 'precond - has li');
 
@@ -192,7 +192,7 @@ test('an input handler will trigger anywhere in the text', (assert) => {
   });
 
   // at start
-  editor.selectRange(new Range(editor.post.headPosition()));
+  editor.selectRange(editor.post.headPosition());
   Helpers.dom.insertText(editor, '@');
   assert.equal(expandCount, 1, 'expansion was run at start');
   assert.deepEqual(lastMatches, ['@'], 'correct match at start');
@@ -204,7 +204,7 @@ test('an input handler will trigger anywhere in the text', (assert) => {
   assert.deepEqual(lastMatches, ['@'], 'correct match at middle');
 
   // end
-  editor.selectRange(new Range(editor.post.tailPosition()));
+  editor.selectRange(editor.post.tailPosition());
   Helpers.dom.insertText(editor, '@');
   assert.equal(expandCount, 3, 'expansion was run at end');
   assert.deepEqual(lastMatches, ['@'], 'correct match at end');

--- a/tests/acceptance/editor-undo-redo-test.js
+++ b/tests/acceptance/editor-undo-redo-test.js
@@ -1,7 +1,5 @@
 import { MODIFIERS } from 'mobiledoc-kit/utils/key';
 import Helpers from '../test-helpers';
-import Position from 'mobiledoc-kit/utils/cursor/position';
-import Range from 'mobiledoc-kit/utils/cursor/range';
 
 const { module, test } = Helpers;
 
@@ -21,7 +19,7 @@ function redo(editor) {
 // See https://github.com/bustlelabs/mobiledoc-kit/issues/388
 function renderIntoAndFocusTail(treeFn, options={}) {
   let editor = Helpers.mobiledoc.renderInto(editorElement, treeFn, options);
-  editor.selectRange(new Range(editor.post.tailPosition()));
+  editor.selectRange(editor.post.tailPosition());
   return editor;
 }
 
@@ -157,8 +155,8 @@ test('undo the deletion of a range', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expectedAfterUndo);
   let { head, tail } = editor.range;
   let section = editor.post.sections.head;
-  assert.positionIsEqual(head, new Position(section, 'a'.length));
-  assert.positionIsEqual(tail, new Position(section, 'abc'.length));
+  assert.positionIsEqual(head, section.toPosition('a'.length));
+  assert.positionIsEqual(tail, section.toPosition('abc'.length));
 
   redo(editor);
   assert.postIsSimilar(editor.post, expectedBeforeUndo);
@@ -166,8 +164,8 @@ test('undo the deletion of a range', (assert) => {
   head = editor.range.head;
   tail = editor.range.tail;
   section = editor.post.sections.head;
-  assert.positionIsEqual(head, new Position(section, 'a'.length));
-  assert.positionIsEqual(tail, new Position(section, 'a'.length));
+  assert.positionIsEqual(head, section.toPosition('a'.length));
+  assert.positionIsEqual(tail, section.toPosition('a'.length));
 });
 
 test('undo insertion of character to a list item', (assert) => {
@@ -195,8 +193,8 @@ test('undo insertion of character to a list item', (assert) => {
     assert.renderTreeIsEqual(editor._renderTree, expectedAfterUndo);
     let { head, tail } = editor.range;
     let section = editor.post.sections.head.items.head;
-    assert.positionIsEqual(head, new Position(section, 'abc'.length));
-    assert.positionIsEqual(tail, new Position(section, 'abc'.length));
+    assert.positionIsEqual(head, section.toPosition('abc'.length));
+    assert.positionIsEqual(tail, section.toPosition('abc'.length));
 
     redo(editor);
     assert.postIsSimilar(editor.post, expectedBeforeUndo);
@@ -204,8 +202,8 @@ test('undo insertion of character to a list item', (assert) => {
     head = editor.range.head;
     tail = editor.range.tail;
     section = editor.post.sections.head.items.head;
-    assert.positionIsEqual(head, new Position(section, 'abcD'.length));
-    assert.positionIsEqual(tail, new Position(section, 'abcD'.length));
+    assert.positionIsEqual(head, section.toPosition('abcD'.length));
+    assert.positionIsEqual(tail, section.toPosition('abcD'.length));
 
     done();
   });

--- a/tests/helpers/post-abstract.js
+++ b/tests/helpers/post-abstract.js
@@ -1,6 +1,4 @@
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
-import Range from 'mobiledoc-kit/utils/cursor/range';
-import Position from 'mobiledoc-kit/utils/cursor/position';
 
 /*
  * usage:
@@ -134,7 +132,7 @@ function parseSingleText(text, builder) {
 
   ['start','end','solo'].forEach(type => {
     if (offsets[type] !== undefined) {
-      positions[type] = new Position(section, offsets[type]);
+      positions[type] = section.toPosition(offsets[type]);
     }
   });
 
@@ -201,9 +199,9 @@ function buildFromText(texts) {
   let range;
   if (positions.start) {
     if (!positions.end) { throw new Error(`startPos but no endPos ${texts.join('\n')}`); }
-    range = new Range(positions.start, positions.end);
+    range = positions.start.toRange(positions.end);
   } else if (positions.solo) {
-    range = new Range(positions.solo);
+    range = positions.solo.toRange();
   }
 
   return { post, range };

--- a/tests/unit/editor/post-delete-at-position-test.js
+++ b/tests/unit/editor/post-delete-at-position-test.js
@@ -1,5 +1,4 @@
 import Helpers from '../../test-helpers';
-import Position from 'mobiledoc-kit/utils/cursor/position';
 
 import { DIRECTION } from 'mobiledoc-kit/utils/key';
 const { FORWARD, BACKWARD } = DIRECTION;
@@ -30,7 +29,7 @@ test('single markup section (backward)', (assert) => {
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, BACKWARD));
 
-    expectedPosition = new Position(post.sections.head, expectedPosition.offset);
+    expectedPosition = post.sections.head.toPosition(expectedPosition.offset);
 
     assert.postIsSimilar(post, expectedPost, `post ${msg}`);
     assert.positionIsEqual(position, expectedPosition, `position ${msg}`);
@@ -56,7 +55,7 @@ test('single markup section (forward)', (assert) => {
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, FORWARD));
 
-    expectedPosition = new Position(post.sections.head, expectedPosition.offset);
+    expectedPosition = post.sections.head.toPosition(expectedPosition.offset);
 
     assert.postIsSimilar(post, expectedPost, `post ${msg}`);
     assert.positionIsEqual(position, expectedPosition, `position ${msg}`);
@@ -78,7 +77,7 @@ test('across section boundary (backward)', (assert) => {
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, BACKWARD));
 
-    expectedPosition = new Position(post.sections.head, expectedPosition.offset);
+    expectedPosition = post.sections.head.toPosition(expectedPosition.offset);
 
     assert.postIsSimilar(post, expectedPost, `post ${msg}`);
     assert.positionIsEqual(position, expectedPosition, `position ${msg}`);
@@ -100,7 +99,7 @@ test('across section boundary (forward)', (assert) => {
 
     position = run(post, postEditor => postEditor.deleteAtPosition(position, FORWARD));
 
-    expectedPosition = new Position(post.sections.head, expectedPosition.offset);
+    expectedPosition = post.sections.head.toPosition(expectedPosition.offset);
 
     assert.postIsSimilar(post, expectedPost, `post ${msg}`);
     assert.positionIsEqual(position, expectedPosition, `position ${msg}`);
@@ -134,7 +133,7 @@ test('across list item boundary (backward)', (assert) => {
       if (index === sectionIndex) { section = _section; }
       index++;
     });
-    expectedPosition = new Position(section, expectedPosition.offset);
+    expectedPosition = section.toPosition(expectedPosition.offset);
 
     assert.postIsSimilar(post, expectedPost, `post ${msg}`);
     assert.positionIsEqual(position, expectedPosition, `position ${msg}`);
@@ -168,7 +167,7 @@ test('across list item boundary (forward)', (assert) => {
       if (index === sectionIndex) { section = _section; }
       index++;
     });
-    expectedPosition = new Position(section, expectedPosition.offset);
+    expectedPosition = section.toPosition(expectedPosition.offset);
 
     assert.postIsSimilar(post, expectedPost, `post ${msg}`);
     assert.positionIsEqual(position, expectedPosition, `position ${msg}`);

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -3,7 +3,6 @@ import { Editor } from 'mobiledoc-kit';
 import Helpers from '../../test-helpers';
 import PostNodeBuilder from 'mobiledoc-kit/models/post-node-builder';
 import Range from 'mobiledoc-kit/utils/cursor/range';
-import Position from 'mobiledoc-kit/utils/cursor/position';
 
 const { module, test } = Helpers;
 
@@ -737,7 +736,7 @@ test('#toggleSection when cursor is in non-markerable section changes nothing', 
   });
 
   mockEditor = renderBuiltAbstract(post, mockEditor);
-  const range = new Range(post.sections.head.headPosition());
+  const range = post.sections.head.headPosition().toRange();
 
   postEditor = new PostEditor(mockEditor);
   postEditor.toggleSection('blockquote', range);
@@ -1194,7 +1193,7 @@ test('#toggleMarkup when cursor is in non-markerable does nothing', (assert) => 
     ]);
   });
 
-  const range = new Range(editor.post.sections.head.headPosition());
+  const range = editor.post.sections.head.headPosition().toRange();
   postEditor = new PostEditor(editor);
   postEditor.toggleMarkup('b', range);
   postEditor.complete();
@@ -1212,7 +1211,7 @@ test('#toggleMarkup when cursor surrounds non-markerable does nothing', (assert)
     ]);
   });
 
-  const range = Range.fromSection(editor.post.sections.head);
+  const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
   postEditor.toggleMarkup('b', range);
   postEditor.complete();
@@ -1232,7 +1231,7 @@ test('#toggleMarkup when range has the markup removes it', (assert) => {
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  const range = Range.fromSection(editor.post.sections.head);
+  const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
   postEditor.toggleMarkup('b', range);
   postEditor.complete();
@@ -1256,7 +1255,7 @@ test('#toggleMarkup when only some of the range has it removes it', (assert) => 
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  const range = Range.fromSection(editor.post.sections.head);
+  const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
   postEditor.toggleMarkup('b', range);
   postEditor.complete();
@@ -1278,7 +1277,7 @@ test('#toggleMarkup when range does not have the markup adds it', (assert) => {
     return post([markupSection('p', [marker('abc', [markup('b')])])]);
   });
 
-  const range = Range.fromSection(editor.post.sections.head);
+  const range = editor.post.sections.head.toRange();
   postEditor = new PostEditor(editor);
   postEditor.toggleMarkup('b', range);
   postEditor.complete();
@@ -1334,7 +1333,7 @@ test('#insertMarkers inserts an atom', (assert) => {
   editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abcdef')])]);
   });
-  let position = new Position(editor.post.sections.head, 'abc'.length);
+  let position = editor.post.sections.head.toPosition('abc'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertMarkers(position, toInsert);
   postEditor.complete();
@@ -1343,7 +1342,7 @@ test('#insertMarkers inserts an atom', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    new Position(editor.post.sections.head, 4)
+    editor.post.sections.head.toPosition(4)
   );
 });
 
@@ -1364,7 +1363,7 @@ test('#insertMarkers inserts the markers in middle, merging markups', (assert) =
   editor = buildEditorWithMobiledoc(({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abcdef')])]);
   });
-  let position = new Position(editor.post.sections.head, 'abc'.length);
+  let position = editor.post.sections.head.toPosition('abc'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertMarkers(position, toInsert);
   postEditor.complete();
@@ -1373,7 +1372,7 @@ test('#insertMarkers inserts the markers in middle, merging markups', (assert) =
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    new Position(editor.post.sections.head, 'abc123456'.length)
+    editor.post.sections.head.toPosition('abc123456'.length)
   );
 });
 
@@ -1402,7 +1401,7 @@ test('#insertMarkers inserts the markers when the markerable has no markers', (a
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    new Position(editor.post.sections.head, '123456'.length)
+    editor.post.sections.head.toPosition('123456'.length)
   );
 });
 
@@ -1431,7 +1430,7 @@ test('#insertMarkers inserts the markers at start', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    new Position(editor.post.sections.head, '123456'.length)
+    editor.post.sections.head.toPosition('123456'.length)
   );
 });
 
@@ -1522,7 +1521,7 @@ test('#insertText inserts the text at start', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    new Position(editor.post.sections.head, '123'.length)
+    editor.post.sections.head.toPosition('123'.length)
   );
 });
 
@@ -1539,7 +1538,7 @@ test('#insertText inserts text in the middle', (assert) => {
   editor = buildEditorWithMobiledoc(({post, markupSection, marker, markup}) => {
     return post([markupSection('p', [marker('abc', [markup('b')])])]);
   });
-  let position = new Position(editor.post.sections.head, 'ab'.length);
+  let position = editor.post.sections.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertText(position, toInsert);
   postEditor.complete();
@@ -1548,7 +1547,7 @@ test('#insertText inserts text in the middle', (assert) => {
   assert.renderTreeIsEqual(editor._renderTree, expected);
   assert.positionIsEqual(
     editor._renderedRange.head,
-    new Position(editor.post.sections.head, 'ab123'.length)
+    editor.post.sections.head.toPosition('ab123'.length)
   );
 });
 
@@ -1594,7 +1593,7 @@ test('#_splitListItem creates two list items', (assert) => {
   });
 
   let item = editor.post.sections.head.items.head;
-  let position = new Position(item, 'abcbo'.length);
+  let position = item.toPosition('abcbo'.length);
   postEditor = new PostEditor(editor);
   postEditor._splitListItem(item, position);
   postEditor.complete();

--- a/tests/unit/editor/post/insert-post-test.js
+++ b/tests/unit/editor/post/insert-post-test.js
@@ -1,7 +1,6 @@
 import PostEditor from 'mobiledoc-kit/editor/post';
 import { Editor } from 'mobiledoc-kit';
 import Helpers from '../../../test-helpers';
-import Position from 'mobiledoc-kit/utils/cursor/position';
 
 const { module, test } = Helpers;
 
@@ -177,7 +176,7 @@ test('in non-nested markerable at middle and paste is single non-markerable', (a
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let position = new Position(editor.post.sections.head, 'ab'.length);
+  let position = editor.post.sections.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -240,7 +239,7 @@ test('in non-nested markerable at middle and paste starts with non-markerable an
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let position = new Position(editor.post.sections.head, 'ab'.length);
+  let position = editor.post.sections.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -249,7 +248,7 @@ test('in non-nested markerable at middle and paste starts with non-markerable an
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.objectAt(2);
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, 'def'.length),
+                         expectedSection.toPosition('def'.length),
                          'cursor at end of pasted');
 });
 
@@ -280,7 +279,7 @@ test('in non-nested markerable at end and paste starts with non-markerable and e
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.tail;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, 'def'.length),
+                         expectedSection.toPosition('def'.length),
                          'cursor at end of pasted');
 });
 
@@ -304,7 +303,7 @@ test('in non-nested markerable at start and paste is single non-nested markerabl
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, '123'.length),
+                         expectedSection.toPosition('123'.length),
                          'cursor at end of pasted');
 });
 
@@ -319,7 +318,7 @@ test('in non-nested markerable at middle and paste is single non-nested markerab
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let position = new Position(editor.post.sections.head, 'ab'.length);
+  let position = editor.post.sections.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -328,7 +327,7 @@ test('in non-nested markerable at middle and paste is single non-nested markerab
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, 'ab123'.length),
+                         expectedSection.toPosition('ab123'.length),
                          'cursor at end of pasted');
 });
 
@@ -377,7 +376,7 @@ test('in non-nested markerable at start and paste is list with 1 item and no mor
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, '123'.length),
+                         expectedSection.toPosition('123'.length),
                          'cursor at end of pasted');
 });
 
@@ -393,7 +392,7 @@ test('in non-nested markerable at middle and paste is list with 1 item and no mo
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let position = new Position(editor.post.sections.head, 'ab'.length);
+  let position = editor.post.sections.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -402,7 +401,7 @@ test('in non-nested markerable at middle and paste is list with 1 item and no mo
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, 'ab123'.length),
+                         expectedSection.toPosition('ab123'.length),
                          'cursor at end of pasted');
 });
 
@@ -486,7 +485,7 @@ test('in non-nested markerable at middle and paste is list with 1 item and has m
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let position = new Position(editor.post.sections.head, 'ab'.length);
+  let position = editor.post.sections.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -620,7 +619,7 @@ test('in non-nested markerable at middle and paste is only list with > 1 item', 
     return post([markupSection('p', [marker('abc')])]);
   });
 
-  let position = new Position(editor.post.sections.head, 'ab'.length);
+  let position = editor.post.sections.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -656,7 +655,7 @@ test('in nested markerable at start and paste is single non-nested markerable', 
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head.items.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, '123'.length),
+                         expectedSection.toPosition('123'.length),
                          'cursor at end of pasted content');
 });
 
@@ -701,7 +700,7 @@ test('in nested markerable at middle and paste is single non-nested markerable',
     return post([listSection('ul', [listItem([marker('abc')])])]);
   });
 
-  let position = new Position(editor.post.sections.head.items.head, 'ab'.length);
+  let position = editor.post.sections.head.items.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -710,7 +709,7 @@ test('in nested markerable at middle and paste is single non-nested markerable',
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head.items.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, 'ab123'.length),
+                         expectedSection.toPosition('ab123'.length),
                          'cursor at end of pasted content');
 });
 
@@ -735,7 +734,7 @@ test('in nested markerable at start and paste is list with 1 item', (assert) => 
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head.items.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, '123'.length),
+                         expectedSection.toPosition('123'.length),
                          'cursor at end of pasted content');
 });
 
@@ -776,7 +775,7 @@ test('in nested markerable at middle and paste is list with 1 item', (assert) =>
     return post([listSection('ul', [listItem([marker('abc')])])]);
   });
 
-  let position = new Position(editor.post.sections.head.items.head, 'ab'.length);
+  let position = editor.post.sections.head.items.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -785,7 +784,7 @@ test('in nested markerable at middle and paste is list with 1 item', (assert) =>
   assert.postIsSimilar(editor.post, expected);
   let expectedSection = editor.post.sections.head.items.head;
   assert.positionIsEqual(renderedRange.head,
-                         new Position(expectedSection, 'ab123'.length),
+                         expectedSection.toPosition('ab123'.length),
                          'cursor at end of pasted content');
 });
 
@@ -856,7 +855,7 @@ test('in nested markerable at middle and paste is list with > 1 item', (assert) 
     return post([listSection('ul', [listItem([marker('abc')])])]);
   });
 
-  let position = new Position(editor.post.sections.head.items.head, 'ab'.length);
+  let position = editor.post.sections.head.items.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();
@@ -980,8 +979,7 @@ test('in nested markerable at middle with multiple items and paste is non-marker
     return post([listSection('ul', [listItem([marker('abc')]), listItem([marker('def')])])]);
   });
 
-  let position = new Position(editor.post.sections.head.items.head,
-                              'ab'.length);
+  let position = editor.post.sections.head.items.head.toPosition('ab'.length);
   postEditor = new PostEditor(editor);
   postEditor.insertPost(position, toInsert);
   postEditor.complete();

--- a/tests/unit/utils/cursor-position-test.js
+++ b/tests/unit/utils/cursor-position-test.js
@@ -25,9 +25,9 @@ test('#move moves forward and backward in markup section', (assert) => {
   let post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
     return post([markupSection('p', [marker('abcd')])]);
   });
-  let position = new Position(post.sections.head, 'ab'.length);
-  let rightPosition = new Position(post.sections.head, 'abc'.length);
-  let leftPosition = new Position(post.sections.head, 'a'.length);
+  let position = post.sections.head.toPosition('ab'.length);
+  let rightPosition = post.sections.head.toPosition('abc'.length);
+  let leftPosition = post.sections.head.toPosition('a'.length);
 
   assert.positionIsEqual(position.move(FORWARD), rightPosition, 'right position');
   assert.positionIsEqual(position.move(BACKWARD), leftPosition, 'left position');
@@ -210,7 +210,7 @@ test('#moveWord in text (backward)', (assert) => {
     let { post, range: { head: pos } } = Helpers.postAbstract.buildFromText(before);
     let { range: { head: afterPos } } = Helpers.postAbstract.buildFromText(after);
 
-    let expectedPos = new Position(post.sections.head, afterPos.offset);
+    let expectedPos = post.sections.head.toPosition(afterPos.offset);
     assert.positionIsEqual(pos.moveWord(BACKWARD), expectedPos,
                            `move word "${before}"->"${after}"`);
   });
@@ -224,7 +224,7 @@ test('#moveWord stops on word-separators', (assert) => {
       return post([markupSection('p', [marker(text)])]);
     });
     let pos = post.tailPosition();
-    let expectedPos = new Position(post.sections.head, 'abc '.length);
+    let expectedPos = post.sections.head.toPosition('abc '.length);
 
     assert.positionIsEqual(pos.moveWord(BACKWARD), expectedPos, `move word <- "${text}|"`);
   });
@@ -246,7 +246,7 @@ test('#moveWord across markerable sections', (assert) => {
   let { post } = Helpers.postAbstract.buildFromText(['abc def', '123 456']);
 
   let [first, second] = post.sections.toArray();
-  let pos = (section, text) => new Position(section, text.length);
+  let pos = (section, text) => section.toPosition(text.length);
   let firstTail = first.tailPosition();
   let secondHead = second.headPosition();
 
@@ -325,8 +325,8 @@ test('#moveWord with atoms (backward)', (assert) => {
 
     let post = buildPostWithTextAndAtom(textWithAtoms);
     let section = post.sections.head;
-    let pos = new Position(section, beforeIndex);
-    let nextPos = new Position(section, afterIndex);
+    let pos = section.toPosition(beforeIndex);
+    let nextPos = section.toPosition(afterIndex);
 
     assert.positionIsEqual(pos.moveWord(BACKWARD), nextPos,
                            `move word with atoms "${before}" -> "${after}"`);
@@ -350,7 +350,7 @@ test('#moveWord in text (forward)', (assert) => {
     let { post, range: { head: pos } } = Helpers.postAbstract.buildFromText(before);
     let { range: { head: nextPos } } = Helpers.postAbstract.buildFromText(after);
     let section = post.sections.head;
-    nextPos = new Position(section, nextPos.offset); // fix section
+    nextPos = section.toPosition(nextPos.offset); // fix section
 
     assert.positionIsEqual(pos.moveWord(FORWARD), nextPos,
                            `move word "${before}"->"${after}"`);
@@ -373,8 +373,8 @@ test('#moveWord with atoms (forward)', (assert) => {
 
     let post = buildPostWithTextAndAtom(textWithAtoms);
     let section = post.sections.head;
-    let pos = new Position(section, beforeIndex);
-    let nextPos = new Position(section, afterIndex);
+    let pos = section.toPosition(beforeIndex);
+    let nextPos = section.toPosition(afterIndex);
 
     assert.positionIsEqual(pos.moveWord(FORWARD), nextPos,
                            `move word with atoms "${before}" -> "${after}"`);
@@ -396,7 +396,7 @@ test('#fromNode when node is marker text node', (assert) => {
   let position = Position.fromNode(renderTree, textNode, 2);
 
   let section = editor.post.sections.head;
-  assert.positionIsEqual(position, new Position(section, 'abc'.length + 2));
+  assert.positionIsEqual(position, section.toPosition('abc'.length + 2));
 });
 
 test('#fromNode when node is section node with offset', (assert) => {
@@ -504,9 +504,9 @@ test('Position cannot be on list section', (assert) => {
 
   let position;
   assert.throws(() => {
-    position = new Position(listSection, 0);
+    position = listSection.toPosition(0);
   }, /addressable by the cursor/);
 
-  position = new Position(listItem, 0);
+  position = listItem.toPosition(0);
   assert.ok(position, 'position with list item is ok');
 });


### PR DESCRIPTION
* Allow `Editor#selectRange`, `postEditor#setRange`, `postEditor#toggleSection`, and `postEditor#toggleMarkup` to receive Range *or* Position
* Add `Position#toRange`, `Section#toRange` and `Post#toRange` methods
* Add `toRange` util to convert range|position into range
* Remove unused `Position#clone`, `Range.fromSection`
* Add `section#toPosition(offset)`
* Expose `Position` on global MobiledocKit export
* docs: label `postEditor#setRange` public fixes #258