### PR TITLE
Use "version" script instead of postversion with --amend --no-edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deploy-website": "./bin/deploy-website.sh",
     "update-changelog": "conventional-changelog -i CHANGELOG.md -r 0 -s",
     "docs": "jsdoc -c ./.jsdoc",
-    "postversion": "npm run update-changelog && git add CHANGELOG.md && git commit --amend --no-edit",
+    "version": "npm run update-changelog && git add CHANGELOG.md",
     "prepublish": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
Using --amend --no-edit was changing the sha of the commit *after* it
had been tagged, which caused issues with future updates to the
changelog. The `git-semver-commits` package failed to find tags when
their commits were amended post-tagging.