### PR TITLE
Add nobreak to links in the editor so toolips are always accessible

### DIFF
--- a/src/css/editor.less
+++ b/src/css/editor.less
@@ -10,8 +10,8 @@
   font-family: 'Lora', Georgia, serif;
   margin: 1em 0;
   color: #454545;
-  /* 
-    Chrome bug adds inline styles when backspacing to join 2 blocks. 
+  /*
+    Chrome bug adds inline styles when backspacing to join 2 blocks.
     Fix: Apply font styles to parent element, or use % for font-size, line-height.
     http://stackoverflow.com/questions/15015019/prevent-chrome-from-wrapping-contents-of-joined-p-with-a-span
   */
@@ -31,6 +31,7 @@
 }
 .__mobiledoc-editor a {
   color: @themeColorText;
+  white-space: nowrap;
 }
 .__mobiledoc-editor {
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
There is case where if a long link wraps, the tooltip to view the outbound link may not be accessible via the mouse.

Before:
<img width="446" alt="screen shot 2016-08-05 at 3 31 54 pm" src="https://cloud.githubusercontent.com/assets/411908/17448887/b1a810c4-5b24-11e6-8506-bef6607b08c0.png">

After:
<img width="445" alt="screen shot 2016-08-05 at 3 50 32 pm" src="https://cloud.githubusercontent.com/assets/411908/17448888/b3bd228c-5b24-11e6-919e-c44913e67401.png">
