### PR TITLE
Added range, direction and unit to delete hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ The available lifecycle hooks are:
    the DOM is updated.
 * `editor.didRender()` - After the DOM has been updated to match the
   edited post.
+* `editor.willDelete((range, direction, unit))` - Provides `range`, `direction` and `unit` to identify the coming deletion.
+* `editor.didDelete((range, direction, unit))` - Provides `range`, `direction` and `unit` to identify the completed deletion.
 * `editor.cursorDidChange()` - When the cursor (or selection) changes as a result of arrow-key
   movement or clicking in the document.
 * `editor.onTextInput()` - When the user adds text to the document (see [example](https://github.com/bustlelabs/mobiledoc-kit#responding-to-text-input))

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -313,13 +313,13 @@ class Editor {
   performDelete({direction, unit}={direction: DIRECTION.BACKWARD, unit: 'char'}) {
     let { range } = this;
 
-    this.runCallbacks(CALLBACK_QUEUES.WILL_DELETE);
+    this.runCallbacks(CALLBACK_QUEUES.WILL_DELETE, [range, direction, unit]);
     if (range.isCollapsed) {
       this.deleteAtPosition(range.head, direction, {unit});
     } else {
       this.deleteRange(range);
     }
-    this.runCallbacks(CALLBACK_QUEUES.DID_DELETE);
+    this.runCallbacks(CALLBACK_QUEUES.DID_DELETE, [range, direction, unit]);
   }
 
   handleNewline(event) {

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -265,15 +265,21 @@ test('failing to delete will not trigger deleting hooks', (assert) => {
 });
 
 test('deleting chracter triggers deleting hooks', (assert) => {
-  assert.expect(3);
+  assert.expect(9);
   let lifeCycles = [];
 
   editor = new Editor({mobiledoc: mobileDocWith2Sections});
-  editor.willDelete(() => {
+  editor.willDelete((range, direction, unit) => {
+    assert.ok(range, 'range is not empty');
+    assert.equal(direction, -1, 'direction defaults to -1');
+    assert.equal(unit, 'char', 'unit defaults to char');
     assert.ok(true, 'willDelete is triggered');
     lifeCycles.push('willDelete');
   });
-  editor.didDelete(() => {
+  editor.didDelete((range, direction, unit) => {
+    assert.ok(range, 'range is not empty');
+    assert.equal(direction, -1, 'direction defaults to -1');
+    assert.equal(unit, 'char', 'unit defaults to char');
     assert.ok(true, 'didDelete is triggered');
     lifeCycles.push('didDelete');
   });


### PR DESCRIPTION
This is for https://github.com/bustlelabs/mobiledoc-kit/issues/450

We have to know the context of deletion to implement WYSIWYG markdown editor. (e.g. know current cursor position, and if it's collapsed... etc.)