### PR TITLE
Refactor rendering of editor element

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -10,7 +10,7 @@ import RenderTree from 'mobiledoc-kit/models/render-tree';
 import mobiledocRenderers from '../renderers/mobiledoc';
 import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
 import { mergeWithOptions } from '../utils/merge';
-import { normalizeTagName, clearChildNodes, addClassName } from '../utils/dom-utils';
+import { normalizeTagName, clearChildNodes } from '../utils/dom-utils';
 import { forEach, filter, contains, values } from '../utils/array-utils';
 import { setData } from '../utils/element-utils';
 import Cursor from '../utils/cursor';
@@ -35,7 +35,9 @@ import LogManager from 'mobiledoc-kit/utils/log-manager';
 import toRange from 'mobiledoc-kit/utils/to-range';
 import MobiledocError from 'mobiledoc-kit/utils/mobiledoc-error';
 
-export const EDITOR_ELEMENT_CLASS_NAME = '__mobiledoc-editor';
+// This export may later be deprecated, but re-export it from the renderer here
+// for consumers that may depend on it.
+export { EDITOR_ELEMENT_CLASS_NAME } from 'mobiledoc-kit/renderers/editor-dom';
 
 const defaults = {
   placeholder: 'Write here...',
@@ -226,7 +228,6 @@ class Editor {
            'rendering of an existing editor instance.',
            !this.hasRendered);
 
-    addClassName(element, EDITOR_ELEMENT_CLASS_NAME);
     element.spellcheck = this.spellcheck;
 
     clearChildNodes(element);
@@ -823,8 +824,12 @@ class Editor {
   // If the editor has a selection but is not focused, focus it
   _ensureFocus() {
     if (this._hasSelection() && !this._hasFocus()) {
-      this.element.focus();
+      this.focus();
     }
+  }
+
+  focus() {
+    this.element.focus();
   }
 
   /**

--- a/src/js/models/image.js
+++ b/src/js/models/image.js
@@ -11,6 +11,10 @@ export default class Image extends Section {
     return false;
   }
 
+  get isBlank() {
+    return false;
+  }
+
   get length() {
     return 1;
   }

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -63,6 +63,21 @@ class Post {
   }
 
   /**
+   * If the post has no sections, or only has one, blank section, then it does
+   * not have content and this method returns false. Otherwise it is true.
+   * @return {Boolean}
+   * @public
+   */
+  get hasContent() {
+    if ((this.sections.length > 1) ||
+        (this.sections.length === 1 && !this.sections.head.isBlank)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
    * @param {Range} range
    * @return {Array} markers that are completely contained by the range
    */

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -12,7 +12,7 @@ import {
   ATOM_TYPE
 } from '../models/types';
 import { startsWith, endsWith } from '../utils/string-utils';
-import { addClassName } from '../utils/dom-utils';
+import { addClassName, removeClassName } from '../utils/dom-utils';
 import { MARKUP_SECTION_ELEMENT_NAMES } from '../models/markup-section';
 import assert from '../utils/assert';
 import { TAB } from 'mobiledoc-kit/utils/characters';
@@ -23,6 +23,8 @@ export const TAB_CHARACTER = '\u2003';
 export const SPACE = ' ';
 export const ZWNJ = '\u200c';
 export const ATOM_CLASS_NAME = '-mobiledoc-kit__atom';
+export const EDITOR_HAS_NO_CONTENT_CLASS_NAME = '__has-no-content';
+export const EDITOR_ELEMENT_CLASS_NAME = '__mobiledoc-editor';
 
 function createElementFromMarkup(doc, markup) {
   let element = doc.createElement(markup.tagName);
@@ -317,6 +319,12 @@ class Visitor {
   [POST_TYPE](renderNode, post, visit) {
     if (!renderNode.element) {
       renderNode.element = document.createElement('div');
+    }
+    addClassName(renderNode.element, EDITOR_ELEMENT_CLASS_NAME);
+    if (post.hasContent) {
+      removeClassName(renderNode.element, EDITOR_HAS_NO_CONTENT_CLASS_NAME);
+    } else {
+      addClassName(renderNode.element, EDITOR_HAS_NO_CONTENT_CLASS_NAME);
     }
     visit(renderNode, post.sections);
   }

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -84,6 +84,10 @@ function addClassName(element, className) {
   element.classList.add(className);
 }
 
+function removeClassName(element, className) {
+  element.classList.remove(className);
+}
+
 function normalizeTagName(tagName) {
   return tagName.toLowerCase();
 }
@@ -101,6 +105,7 @@ export {
   walkDOM,
   walkTextNodes,
   addClassName,
+  removeClassName,
   normalizeTagName,
   isTextNode,
   isCommentNode,

--- a/tests/helpers/assertions.js
+++ b/tests/helpers/assertions.js
@@ -135,6 +135,26 @@ export default function registerAssertions() {
     return found;
   };
 
+  QUnit.assert.hasClass = function(element, className,
+                               message=`element has class "${className}"`) {
+    this.pushResult({
+      result: element.classList.contains(className),
+      actual: element.classList,
+      expected: className,
+      message
+    });
+  };
+
+  QUnit.assert.notHasClass = function(element, className,
+                               message=`element has class "${className}"`) {
+    this.pushResult({
+      result: !element.classList.contains(className),
+      actual: element.classList,
+      expected: className,
+      message
+    });
+  };
+
   QUnit.assert.selectedText = function(text, message=`selectedText "${text}"`) {
     const selected = DOMHelper.getSelectedText();
     this.push(selected === text,

--- a/tests/helpers/post-abstract.js
+++ b/tests/helpers/post-abstract.js
@@ -21,6 +21,7 @@ function build(treeFn) {
     listSection   : (...args) => builder.createListSection(...args),
     listItem      : (...args) => builder.createListItem(...args),
     cardSection   : (...args) => builder.createCardSection(...args),
+    imageSection  : (...args) => builder.createImageSection(...args),
     atom          : (...args) => builder.createAtom(...args)
   };
 

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -1,5 +1,5 @@
 import Editor from 'mobiledoc-kit/editor/editor';
-import { EDITOR_ELEMENT_CLASS_NAME } from 'mobiledoc-kit/editor/editor';
+import { EDITOR_ELEMENT_CLASS_NAME, EDITOR_HAS_NO_CONTENT_CLASS_NAME } from 'mobiledoc-kit/renderers/editor-dom';
 import { normalizeTagName } from 'mobiledoc-kit/utils/dom-utils';
 import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc/0-2';
 import Range from 'mobiledoc-kit/utils/cursor/range';
@@ -58,7 +58,7 @@ test('rendering an editor without a class name adds appropriate class', (assert)
 
   editor = new Editor();
   editor.render(editorElement);
-  assert.equal(editor.element.className, EDITOR_ELEMENT_CLASS_NAME);
+  assert.hasClass(editor.element, EDITOR_ELEMENT_CLASS_NAME);
 });
 
 test('rendering an editor adds EDITOR_ELEMENT_CLASS_NAME if not there', (assert) => {
@@ -66,9 +66,29 @@ test('rendering an editor adds EDITOR_ELEMENT_CLASS_NAME if not there', (assert)
 
   editor = new Editor();
   editor.render(editorElement);
-  const hasClass = (className) => editor.element.classList.contains(className);
-  assert.ok(hasClass(EDITOR_ELEMENT_CLASS_NAME), 'has editor el class name');
-  assert.ok(hasClass('abc') && hasClass('def'), 'preserves existing class names');
+
+  assert.hasClass(editor.element, EDITOR_ELEMENT_CLASS_NAME, `adds ${EDITOR_ELEMENT_CLASS_NAME}`);
+  assert.hasClass(editor.element, 'abc', 'preserves existing classnames');
+  assert.hasClass(editor.element, 'def', 'preserves existing classnames');
+});
+
+test('rendering an editor adds EDITOR_HAS_NO_CONTENT_CLASS_NAME if post has no content', (assert) => {
+  editor = new Editor();
+  assert.ok(!editor.post.hasContent, 'precond - post has no content');
+  editor.render(editorElement);
+
+  assert.hasClass(editorElement, EDITOR_HAS_NO_CONTENT_CLASS_NAME);
+
+  // Firefox requires that the cursor be placed explicitly for this test to pass,
+  // `editor.focus()` won't work when running this test on CI in Firefox
+  Helpers.dom.moveCursorTo(editor, editor.element, 0);
+
+  editor.insertText('abc');
+  assert.ok(editor.post.hasContent, 'editor has content');
+  assert.notHasClass(editorElement, EDITOR_HAS_NO_CONTENT_CLASS_NAME, `removes "${EDITOR_HAS_NO_CONTENT_CLASS_NAME}" when editor has content`);
+
+  editor.deleteRange(editor.post.toRange());
+  assert.hasClass(editorElement, EDITOR_HAS_NO_CONTENT_CLASS_NAME, `adds "${EDITOR_HAS_NO_CONTENT_CLASS_NAME}" after editor content is all deleted`);
 });
 
 test('editor fires lifecycle hooks', (assert) => {

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -509,3 +509,37 @@ test('#headPosition and #tailPosition when post is blank return blank', (assert)
   assert.positionIsEqual(head, Position.blankPosition(), 'head pos');
   assert.positionIsEqual(tail, Position.blankPosition(), 'tail pos');
 });
+
+test('#hasContent gives correct value', (assert) => {
+  let expectations = Helpers.postAbstract.build(({post, markupSection, imageSection, marker}) => {
+    return {
+      hasNoContent: [{
+        message: 'no sections',
+        post: post()
+      }, {
+        message: '1 blank section',
+        post: post([markupSection('p')])
+      }, {
+        message: '1 section with blank marker',
+        post: post([markupSection('p', [marker('')])])
+      }],
+      hasContent: [{
+        message: '1 section with non-blank marker',
+        post: post([markupSection('p', [marker('text')])])
+      }, {
+        message: '2 sections',
+        post: post([markupSection('p'), markupSection('p')])
+      }, {
+        message: 'image section',
+        post: post([imageSection()])
+      }]
+    };
+  });
+
+  expectations.hasNoContent.forEach(({message, post}) => {
+    assert.ok(!post.hasContent, message + ' !hasContent');
+  });
+  expectations.hasContent.forEach(({message, post}) => {
+    assert.ok(post.hasContent, message + ' hasContent');
+  });
+});

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -29,6 +29,7 @@ module('Unit: Renderer: Editor-Dom', {
     }
     if (editor) {
       editor.destroy();
+      editor = null;
     }
   }
 });
@@ -58,7 +59,7 @@ test("renders a dirty post with un-rendered sections", (assert) => {
   const renderTree = new RenderTree(post);
   render(renderTree);
 
-  assert.equal(renderTree.rootElement.outerHTML, '<div><p><br></p><p><br></p></div>',
+  assert.equal(renderTree.rootElement.innerHTML, '<p><br></p><p><br></p>',
                'correct HTML is rendered');
 
   assert.ok(renderTree.rootNode.childNodes.head,


### PR DESCRIPTION
Adding a new class name ("__has-no-content") to the editor element when
the post has no content will simplify rendering of the placeholder text
later.

 * Add `Post#hasContent` (fixes #335)
 * Add `editor#focus()`
 * Move EDITOR_ELEMENT_CLASS_NAME to renderers/editor-dom
 * Make the editor-dom renderer responsible for adding EDITOR_ELEMENT_CLASS_NAME
 * Make the editor-dom renderer responsible for adding EDITOR_HAS_NO_CONTENT_CLASS_NAME if post has no content