### PR TITLE
Fix insertion into blank section

### DIFF
--- a/tests/helpers/editor.js
+++ b/tests/helpers/editor.js
@@ -1,0 +1,54 @@
+import PostAbstractHelpers from './post-abstract';
+import Editor from 'mobiledoc-kit/editor/editor';
+import MobiledocRenderer from 'mobiledoc-kit/renderers/mobiledoc/0-3';
+
+function retargetPosition(position, fromPost, toPost) {
+  let sectionIndex;
+  let retargetedPosition;
+  fromPost.walkAllLeafSections((section,index) => {
+    if (sectionIndex !== undefined) { return; }
+    if (section === position.section) { sectionIndex = index; }
+  });
+  if (sectionIndex === undefined) {
+    throw new Error('`retargetPosition` could not find section index');
+  }
+  toPost.walkAllLeafSections((section, index) => {
+    if (retargetedPosition) { return; }
+    if (index === sectionIndex) {
+      retargetedPosition = section.toPosition(position.offset);
+    }
+  });
+  if (!retargetedPosition) {
+    throw new Error('`retargetPosition` could not find target section');
+  }
+  return retargetedPosition;
+}
+
+function retargetRange(range, toPost) {
+  let fromPost = range.head.section.post;
+  let newHead = retargetPosition(range.head, fromPost, toPost);
+  let newTail = retargetPosition(range.tail, fromPost, toPost);
+
+  return newHead.toRange(newTail);
+}
+
+function buildFromText(texts, editorOptions={}) {
+  let renderElement = editorOptions.element;
+  delete editorOptions.element;
+
+  let {post, range} = PostAbstractHelpers.buildFromText(texts);
+  let mobiledoc = MobiledocRenderer.render(post);
+  editorOptions.mobiledoc = mobiledoc;
+  let editor = new Editor(editorOptions);
+  if (renderElement) {
+    editor.render(renderElement);
+    range = retargetRange(range, editor.post);
+    editor.selectRange(range);
+  }
+  return editor;
+}
+
+export {
+  buildFromText,
+  retargetRange
+};

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -9,6 +9,7 @@ import wait from './helpers/wait';
 import MockEditor from './helpers/mock-editor';
 import renderBuiltAbstract from './helpers/render-built-abstract';
 import run from './helpers/post-editor-run';
+import EditorHelpers from './helpers/editor';
 
 const { test:qunitTest, module, skip } = QUnit;
 
@@ -45,6 +46,7 @@ export default {
   dom: DOMHelpers,
   mobiledoc: MobiledocHelpers,
   postAbstract: PostAbstract,
+  editor: EditorHelpers,
   test,
   module,
   skipInIE11,


### PR DESCRIPTION
* Refactor #insertPost tests to use builder and editor DSL.
* Add test helper editor DSL `Helpers.editor.buildFromText(dsl, editorOptions)`
* Add test helper `retargetRange` to retarget a range from one post to
  another. Helps with asserting that the editor's range matches the one
  from the DSL

Fixes #462