### PR TITLE
Implement Atom `save` hook

### DIFF
--- a/ATOMS.md
+++ b/ATOMS.md
@@ -29,6 +29,7 @@ must be of the correct type (a DOM Node for the dom renderer, a string of html o
 
   * `name` [string] - the name of the atom
   * `onTeardown` [function] - The atom can pass a callback function: `onTeardown(callbackFn)`. The callback will be called when the rendered content is torn down.
+  * `save` [function] - Call this function with the arguments `(newValue, newPayload)` to update the atom's value and payload and rerender it.
 
 ## Atom Examples
 
@@ -53,6 +54,26 @@ let atom = {
    env.onTeardown(() => {
     console.log('tearing down atom named: ' + env.name);
    });
+ }
+};
+```
+
+Example dom atom that uses the `save` hook:
+```js
+let atom = {
+ name: 'click-counter',
+ type: 'dom',
+ render({env, value, payload}) {
+   let clicks = payload.clicks || 0;
+   let button = document.createElement('button');
+   button.appendChild(document.createTextNode('Clicks: ' + clicks));
+
+   button.onclick = () => {
+     payload.clicks = clicks + 1;
+     env.save(value, payload); // updates payload.clicks, rerenders button
+   };
+
+   return button;
  }
 };
 ```

--- a/src/js/models/atom-node.js
+++ b/src/js/models/atom-node.js
@@ -25,7 +25,15 @@ export default class AtomNode {
   get env() {
     return {
       name: this.atom.name,
-      onTeardown: (callback) => this._teardownCallback = callback
+      onTeardown: (callback) => this._teardownCallback = callback,
+      save: (value, payload={}) => {
+        this.model.value = value;
+        this.model.payload = payload;
+
+        this.editor._postDidChange();
+        this.teardown();
+        this.render();
+      }
     };
   }
 

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -134,13 +134,13 @@ class PostNodeBuilder {
 
   /**
    * @param {String} name
-   * @param {String} [text='']
+   * @param {String} [value='']
    * @param {Object} [payload={}]
    * @param {Markup[]} [markups=[]]
    * @return {Atom}
    */
-  createAtom(name, text='', payload={}, markups=[]) {
-    const atom = new Atom(name, text, payload, markups);
+  createAtom(name, value='', payload={}, markups=[]) {
+    const atom = new Atom(name, value, payload, markups);
     atom.builder = this;
     return atom;
   }


### PR DESCRIPTION
Save hook is on the atom's `env` and accepts arguments: `(value, payload)`.
Calling the save hook rerenders the atom.

Example:
```
let atom = {
  name: 'my-atom',
  type: 'dom',
  render({env, value, payload}) {
    let el = document.createElement('button');
    let clicks = payload.clicks || 0;
    el.appendChild(document.createTextNode('Clicks: ' + clicks));
    el.onclick = () => {
      payload.clicks = payload.clicks || 0;
      payload.clicks++;
      env.save(value, payload);
    };
    return el;
  }
};
```

Also: improve postAbstract buildFromText to accept data for an atom,
i.e. "abc@(...jsondata...)", e.g.:
```
buildFromText('abc@("name": "my-atom", "value": "bob", "payload": {"foo": "bar"})def');
// -> "abc" + atom with name "my-atom", value "bob", payload {foo: 'bar'} + "def"
```

Fixes #399