### PR TITLE
Allow reading range from DOM when editor is disabled

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -395,9 +395,6 @@ class Editor {
   }
 
   _readRangeFromDOM() {
-    if (!this.isEditable) {
-      return;
-    }
     this.range = this.cursor.offsets;
   }
 

--- a/tests/helpers/editor.js
+++ b/tests/helpers/editor.js
@@ -36,14 +36,20 @@ function buildFromText(texts, editorOptions={}) {
   let renderElement = editorOptions.element;
   delete editorOptions.element;
 
+  let beforeRender = editorOptions.beforeRender || () => {};
+  delete editorOptions.beforeRender;
+
   let {post, range} = PostAbstractHelpers.buildFromText(texts);
   let mobiledoc = MobiledocRenderer.render(post);
   editorOptions.mobiledoc = mobiledoc;
   let editor = new Editor(editorOptions);
   if (renderElement) {
+    beforeRender(editor);
     editor.render(renderElement);
-    range = retargetRange(range, editor.post);
-    editor.selectRange(range);
+    if (range) {
+      range = retargetRange(range, editor.post);
+      editor.selectRange(range);
+    }
   }
   return editor;
 }


### PR DESCRIPTION
Because `_readRangeFromDOM` doesn't do anything
if the editor is non-editable, the editor may get stuck with a range
that is pointing at a section that has been removed from the post.
This causes the error seen when doing the `post.walkAllLeafSections`
later in the snapshot code. The post is undefined because it is read off
the card, but the card that the range points at has been removed.

Fixes #475