### PR TITLE
Remove newline chars in text nodes (`\n`) when parsing HTML

### DIFF
--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -44,6 +44,12 @@ const SKIPPABLE_ELEMENT_TAG_NAMES = [
   'style', 'head', 'title', 'meta'
 ].map(normalizeTagName);
 
+const NEWLINES = /\n/g;
+function sanitize(text) {
+  text = text.replace(NEWLINES, '');
+  return text;
+}
+
 /**
  * parses an element into a section, ignoring any non-markup
  * elements contained within
@@ -167,7 +173,7 @@ class SectionParser {
 
   parseTextNode(textNode) {
     let { state } = this;
-    state.text += textNode.textContent;
+    state.text += sanitize(textNode.textContent);
   }
 
   _updateStateFromElement(element) {

--- a/tests/helpers/post-abstract.js
+++ b/tests/helpers/post-abstract.js
@@ -113,11 +113,7 @@ function parseTextIntoMarkers(text, builder) {
         markers = markers.concat( parseTextIntoMarkers(piece, builder) );
       }
     });
-  } else if (text.indexOf('*') === -1) {
-    if (text.length) {
-      markers.push(builder.marker(text));
-    }
-  } else {
+  } else if (text.indexOf('*') !== -1) {
     let markup = builder.markup('b');
 
     let startIndex = text.indexOf('*');
@@ -133,6 +129,10 @@ function parseTextIntoMarkers(text, builder) {
         markers.push(builder.marker(piece, markups));
       }
     });
+  } else {
+    if (text.length) {
+      markers.push(builder.marker(text));
+    }
   }
 
   return markers;

--- a/tests/unit/parsers/html-test.js
+++ b/tests/unit/parsers/html-test.js
@@ -24,3 +24,11 @@ test('style tags are ignored', (assert) => {
   assert.postIsSimilar(post, expected);
 });
 
+// See https://github.com/bustlelabs/mobiledoc-kit/issues/333
+test('newlines ("\\n") are ignored', (assert) => {
+  let html = "abc\ndef";
+  let post = parseHTML(html);
+  let {post: expected} = Helpers.postAbstract.buildFromText(['abcdef']);
+
+  assert.postIsSimilar(post, expected);
+});


### PR DESCRIPTION
Fixes #333