### PR TITLE
Ensure `onTextInput` is triggered by tab character

### DIFF
--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -6,7 +6,6 @@ import {
 } from 'mobiledoc-kit/utils/parse-utils';
 import { filter, forEach } from 'mobiledoc-kit/utils/array-utils';
 import Key from 'mobiledoc-kit/utils/key';
-import { TAB } from 'mobiledoc-kit/utils/characters';
 import TextInputHandler from 'mobiledoc-kit/editor/text-input-handler';
 import SelectionManager from 'mobiledoc-kit/editor/selection-manager';
 import Browser from 'mobiledoc-kit/utils/browser';
@@ -173,8 +172,9 @@ export default class EventManager {
         editor.handleNewline(event);
         break;
       case key.isTab():
+        // Handle tab here because it does not fire a `keypress` event
         event.preventDefault();
-        editor.insertText(TAB);
+        this._textInputHandler.handle(key.toString());
         break;
     }
   }

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -1,4 +1,6 @@
 import Keycodes from './keycodes';
+import { TAB } from 'mobiledoc-kit/utils/characters';
+
 /**
  * @typedef Direction
  * @enum {number}
@@ -74,6 +76,7 @@ const Key = class Key {
   }
 
   toString() {
+    if (this.isTab()) { return TAB; }
     return String.fromCharCode(this.charCode);
   }
 

--- a/tests/unit/utils/cursor-position-test.js
+++ b/tests/unit/utils/cursor-position-test.js
@@ -234,7 +234,11 @@ test('#moveWord does not stop on non-word-separators', (assert) => {
   let nonSeparators = ['_', ':'];
   nonSeparators.forEach(sep => {
     let text = `abc${sep}def`;
-    let { post } = Helpers.postAbstract.buildFromText(text);
+
+    // Have to use `build` function here because "_" is a special char for `buildFromText`
+    let post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+      return post([markupSection('p', [marker(text)])]);
+    });
     let pos = post.tailPosition();
     let nextPos = post.headPosition();
 


### PR DESCRIPTION
Change the event manager to delegate insertion of tab key to the input
handler rather than simply inserting the string.

Also: Lot of cleanup to tests.

Fixes #400