### PR TITLE
Make deprecate accept conditional argument

### DIFF
--- a/src/js/utils/deprecate.js
+++ b/src/js/utils/deprecate.js
@@ -1,3 +1,14 @@
-export default function deprecate(message) {
-  console.log(`[mobiledoc-kit] [DEPRECATED]: ${message}`); // jshint ignore:line
+/**
+ * Usage:
+ * Without a conditional, always prints deprecate message:
+ *   `deprecate('This is deprecated')`
+ *
+ * Conditional deprecation, works similarly to `assert`, prints deprecation if
+ * conditional is false:
+ *   `deprecate('Deprecated only if foo !== bar', foo === bar)`
+ */
+export default function deprecate(message, conditional=false) {
+  if (!conditional) {
+    console.log(`[mobiledoc-kit] [DEPRECATED]: ${message}`); // jshint ignore:line
+  }
 }


### PR DESCRIPTION
cc @eguitarz apologies, I misinformed you in #484; `deprecate` did not accept a second
conditional argument, but after this it will.

This fixes some noisy console logging from the built-in text input helpers.