### PR TITLE
add willHandleNewline hook

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -63,6 +63,7 @@ const CALLBACK_QUEUES = {
   DID_RENDER: 'didRender',
   WILL_DELETE: 'willDelete',
   DID_DELETE: 'didDelete',
+  WILL_HANDLE_NEWLINE: 'willHandleNewline',
   CURSOR_DID_CHANGE: 'cursorDidChange',
   DID_REPARSE: 'didReparse',
   POST_DID_CHANGE: 'postDidChange',
@@ -339,6 +340,13 @@ class Editor {
           return;
         }
       }
+
+      // Above logic might delete redundant range, so callback must run after it.
+      let defaultPrevented = false;
+      const event = { preventDefault() { defaultPrevented = true; } };
+      this.runCallbacks(CALLBACK_QUEUES.WILL_HANDLE_NEWLINE, [event]);
+      if (defaultPrevented) { return; }
+
       cursorSection = postEditor.splitSection(range.head)[1];
       postEditor.setRange(cursorSection.headPosition());
     });
@@ -784,6 +792,14 @@ class Editor {
    */
   didDelete(callback) {
     this.addCallback(CALLBACK_QUEUES.DID_DELETE, callback);
+  }
+
+  /**
+   * @param {Function} callback This callback will be called before handling new line.
+   * @public
+   */
+  willHandleNewline(callback) {
+    this.addCallback(CALLBACK_QUEUES.WILL_HANDLE_NEWLINE, callback);
   }
 
   /**

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -210,3 +210,17 @@ test('keypress events when the editor does not have selection are ignored', (ass
     done();
   });
 });
+
+test('prevent handling newline', (assert) => {
+  editor = Helpers.editor.buildFromText('', {element: editorElement});
+
+  editor.willHandleNewline(event => {
+    assert.ok(true, 'willHandleNewline should be triggered');
+    event.preventDefault();
+  });
+  let {post: expected} = Helpers.postAbstract.buildFromText(['Line1']);
+
+  Helpers.dom.insertText(editor, 'Line1');
+  Helpers.dom.insertText(editor, ENTER);
+  assert.postIsSimilar(editor.post, expected);
+});


### PR DESCRIPTION
- It addresses #481 
- I was planning to handle newline base on callback return value. But current callback structure omits the return values. Instead, I passed a parameter into `willHandleNewline` and handle newline base on its value is changed or not.