### PR TITLE
Add range to willHandleNewline hook

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -344,7 +344,7 @@ class Editor {
       // Above logic might delete redundant range, so callback must run after it.
       let defaultPrevented = false;
       const event = { preventDefault() { defaultPrevented = true; } };
-      this.runCallbacks(CALLBACK_QUEUES.WILL_HANDLE_NEWLINE, [event]);
+      this.runCallbacks(CALLBACK_QUEUES.WILL_HANDLE_NEWLINE, [event, this, range]);
       if (defaultPrevented) { return; }
 
       cursorSection = postEditor.splitSection(range.head)[1];

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -344,7 +344,7 @@ class Editor {
       // Above logic might delete redundant range, so callback must run after it.
       let defaultPrevented = false;
       const event = { preventDefault() { defaultPrevented = true; } };
-      this.runCallbacks(CALLBACK_QUEUES.WILL_HANDLE_NEWLINE, [event, this, range]);
+      this.runCallbacks(CALLBACK_QUEUES.WILL_HANDLE_NEWLINE, [event, this]);
       if (defaultPrevented) { return; }
 
       cursorSection = postEditor.splitSection(range.head)[1];

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -149,7 +149,7 @@ test('select-all and type text works ok', (assert) => {
 
   assert.selectedText('abc', 'precond - abc is selected');
   assert.hasElement('#editor p:contains(abc)', 'precond - renders p');
-  
+
   Helpers.dom.insertText(editor, 'X');
 
   assert.hasNoElement('#editor p:contains(abc)', 'replaces existing text');
@@ -214,7 +214,8 @@ test('keypress events when the editor does not have selection are ignored', (ass
 test('prevent handling newline', (assert) => {
   editor = Helpers.editor.buildFromText('', {element: editorElement});
 
-  editor.willHandleNewline(event => {
+  editor.willHandleNewline((event, editor, range) => {
+    assert.equal(range.head.section.text, 'Line1', 'can access section text');
     assert.ok(true, 'willHandleNewline should be triggered');
     event.preventDefault();
   });

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -214,7 +214,7 @@ test('keypress events when the editor does not have selection are ignored', (ass
 test('prevent handling newline', (assert) => {
   editor = Helpers.editor.buildFromText('', {element: editorElement});
 
-  editor.willHandleNewline((event, editor, range) => {
+  editor.willHandleNewline((event, {range}) => {
     assert.equal(range.head.section.text, 'Line1', 'can access section text');
     assert.ok(true, 'willHandleNewline should be triggered');
     event.preventDefault();


### PR DESCRIPTION
I find out I have to access current section context to determine to disable newline or not. Seems add the editor and range into current hook callback is the easiest way.

The reason we also need editor, is to allow user to modify post in willHandleNewline callback.