### PR TITLE
Group Undos

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A toolkit for building WYSIWYG editors with Mobiledoc",
   "repository": "https://github.com/bustlelabs/mobiledoc-kit",
   "scripts": {
-    "start": "broccoli serve",
+    "start": "broccoli serve --host 0.0.0.0",
     "test:ci": "npm run build:docs && npm run build && testem ci -f testem-ci.json",
     "test": "PATH=node_modules/phantomjs-prebuilt/bin/:$PATH npm run build:docs && npm run build && testem ci -f testem.json",
     "build": "rm -rf dist && broccoli build dist",

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -43,6 +43,7 @@ const defaults = {
   spellcheck: true,
   autofocus: true,
   undoDepth: 5,
+  undoBlockTimeout: 5000, // ms for an undo event
   cards: [],
   atoms: [],
   cardOptions: {},
@@ -135,7 +136,7 @@ class Editor {
     this.post = this.loadPost();
     this._renderTree = new RenderTree(this.post);
 
-    this._editHistory = new EditHistory(this, this.undoDepth);
+    this._editHistory = new EditHistory(this, this.undoDepth, this.undoBlockTimeout);
     this._eventManager = new EventManager(this);
     this._mutationHandler = new MutationHandler(this);
     this._editState = new EditState(this);
@@ -687,7 +688,7 @@ class Editor {
     if (postEditor._shouldCancelSnapshot) {
       this._editHistory._pendingSnapshot = null;
     }
-    this._editHistory.storeSnapshot();
+    this._editHistory.storeSnapshot(postEditor.editActionTaken);
 
     return result;
   }


### PR DESCRIPTION
Refs #502

Basically there are three types of undo events, `insert`, `delete`, and everything else (which is undefined here).

`Insert` and `delete` events group together overwriting the last element in the undo queue when they are repeated unless another event occurs which breaks it or a timeout occurs.

So, if I write text then as long as I don't delete text or insert an atom or card, and as long as the timeout doesn't occur, those events are grouped by replacing the last element on the undo queue and are popped in one go.

A timeout is reset whenever the `run` method is called on the editor, so it doesn't happen on the first occurrence of an event in a run but rather the last.
