### PR TITLE
range#expandByMarker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 ---
 language: node_js
 node_js:
-  - "stable"
+  - "6"
 
-sudo: required
-dist: trusty
+sudo: false
 
 cache:
   directories:
@@ -12,8 +11,10 @@ cache:
     - $HOME/.yarn-cache
 
 before_install:
+  - npm config set spin false
   - npm install -g yarn
   - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - yarn

--- a/README.md
+++ b/README.md
@@ -128,6 +128,62 @@ document's `<head>`:
   immediately if the card is already rendered, or will ensure that when the card
   does get rendered it will be rendered in the "edit" state initially)
 * `editor.displayCard(cardSection)` - same as `editCard` except in display mode.
+* `editor.range` - Read the current Range object for the cursor.
+
+### Position API
+
+A `Position` object represents a location in a document. For example your
+cursor may be at a position, text may be inserted at a position, and a range
+has a starting position and an ending position.
+
+Position objects are returned by several APIs, for example `deleteRange` returns
+a position. Some methods, like `splitSection` accept a position as an argument.
+
+A position can be created for any point in a document with
+`section#toPosition(offset)`.
+
+Position API includes:
+
+* `position.section` - The section of this position
+* `position.offset` - The character offset of this position in the section.
+* `position.marker` - Based on the section and offset, the marker this position
+  if on. A position may not always have a marker (for example a cursor before
+  or after a card).
+* `position.toRange(endPosition)` - Create a range based on two positions. Accepts
+  the direction of the range as a second optional argument.
+* `position.isEqual(otherPosition)` - Is this position the same as another
+* `position.move(characterCount)` - Move a number of characters to the right
+  (positive number) or left (negative number)
+* `position.moveWord(direction)` - Move a single word in a given direction.
+
+### Range API
+
+`Range` represent a range of a document. A range has a starting position
+(`head`), ending position (`tail`), and a direction (for example highlighting
+text left-to-right is a forward direction, highlighting right-to-left is a
+backward direction).
+
+Ranges are retured by serveral APIs, but most often you will be interested in
+the current range selected by the user (be it their cursor or an actual
+selection). This can be accessed at `editor#range`. Several post editor APIs
+expect a range as an argument, for example `setRange` or `deleteRange`.
+
+Ranges sport several public APIs for manipulation, each of which returns a new,
+unique range instance:
+
+* `range.head` - The position on the range closer to the start of the document.
+* `range.tail` - The position on the range closer to the end of the document.
+* `range.isCollapsed` - A range is collapsed when its head and tail are the same
+  position.
+* `range.focusedPosition` - If a range has a forward direction, then tail. If
+  it has a backward direction, the head.
+* `range.extend(characterCount)` - Grow a range one character in whatever its
+  direction is.
+* `range.move(direction)` - If the range is collapsed, move the range forward
+  one character. If it is not, collapse it in the direction passed.
+* `range.expandByMarker(callback)` - In both directions attempt grow the
+  range as long as `callback` returns true. `callback` is passed each marker
+  as the range is grown.
 
 ### Editor Lifecycle Hooks
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "broccoli serve",
     "test:ci": "npm run build:docs && npm run build && testem ci -f testem-ci.json",
-    "test": "npm run build:docs && npm run build && testem ci -f testem.json",
+    "test": "PATH=node_modules/phantomjs-prebuilt/bin/:$PATH npm run build:docs && npm run build && testem ci -f testem.json",
     "build": "rm -rf dist && broccoli build dist",
     "build:docs": "jsdoc -c ./.jsdoc",
     "build:website": "npm run build && npm run build:docs && ./bin/build-website.sh",

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -11,7 +11,7 @@ import mobiledocRenderers from '../renderers/mobiledoc';
 import { MOBILEDOC_VERSION } from 'mobiledoc-kit/renderers/mobiledoc';
 import { mergeWithOptions } from '../utils/merge';
 import { normalizeTagName, clearChildNodes } from '../utils/dom-utils';
-import { forEach, filter, contains, values } from '../utils/array-utils';
+import { forEach, filter, contains, values, detect } from '../utils/array-utils';
 import { setData } from '../utils/element-utils';
 import Cursor from '../utils/cursor';
 import Range from '../utils/cursor/range';
@@ -22,7 +22,6 @@ import {
   DEFAULT_KEY_COMMANDS, buildKeyCommand, findKeyCommands, validateKeyCommand
 } from './key-commands';
 import { CARD_MODES } from '../models/card';
-import { detect } from '../utils/array-utils';
 import assert from '../utils/assert';
 import MutationHandler from 'mobiledoc-kit/editor/mutation-handler';
 import EditHistory from 'mobiledoc-kit/editor/edit-history';

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -110,8 +110,8 @@ Position = class Position {
    * @return {Range}
    * @public
    */
-  toRange(tail=this) {
-    return new Range(this, tail);
+  toRange(tail=this, direction=null) {
+    return new Range(this, tail, direction);
   }
 
   get leafSectionIndex() {

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -117,6 +117,40 @@ class Range {
     }
   }
 
+  /**
+   * expand a range to all markers matching a given check
+   *
+   * @param {Function} detectMarker
+   * @return {Range} The expanded range
+   *
+   * @public
+   */
+  expandByMarker(detectMarker) {
+    let {
+      head,
+      tail,
+      direction
+    } = this;
+    let {section: headSection} = head;
+    if (headSection !== tail.section) {
+      throw new Error('#expandByMarker does not work across sections. Perhaps you should confirm the range is collapsed');
+    }
+
+    let firstNotMatchingDetect = i => {
+      return !detectMarker(i);
+    };
+
+    let headMarker = head.section.markers.detect(firstNotMatchingDetect, head.marker, true);
+    headMarker = (headMarker && headMarker.next) || head.marker;
+    let headPosition = new Position(headSection, headSection.offsetOfMarker(headMarker));
+
+    let tailMarker = tail.section.markers.detect(firstNotMatchingDetect, tail.marker);
+    tailMarker = (tailMarker && tailMarker.prev) || tail.marker;
+    let tailPosition = new Position(tail.section, tail.section.offsetOfMarker(tailMarker) + tailMarker.length);
+
+    return headPosition.toRange(tailPosition, direction);
+  }
+
   _collapse(direction) {
     return new Range(direction === DIRECTION.BACKWARD ? this.head : this.tail);
   }

--- a/src/js/utils/linked-list.js
+++ b/src/js/utils/linked-list.js
@@ -143,12 +143,12 @@ export default class LinkedList {
   toArray() {
     return this.readRange();
   }
-  detect(callback, item=this.head) {
+  detect(callback, item=this.head, reverse=false) {
     while (item) {
       if (callback(item)) {
         return item;
       }
-      item = item.next;
+      item = reverse ? item.prev : item.next;
     }
   }
   any(callback) {

--- a/tests/unit/utils/linked-list-test.js
+++ b/tests/unit/utils/linked-list-test.js
@@ -370,6 +370,30 @@ test(`#detect finds`, (assert) => {
   assert.equal(list.detect(() => false), undefined, 'no item detected');
 });
 
+test(`#detect finds w/ start`, (assert) => {
+  let list = new LinkedList();
+  let itemOne = new LinkedItem();
+  let itemTwo = new LinkedItem();
+  let itemThree = new LinkedItem();
+  list.append(itemOne);
+  list.append(itemTwo);
+  list.append(itemThree);
+  assert.equal(list.detect(item => item === itemOne, itemOne), itemOne, 'itemOne detected');
+  assert.equal(list.detect(item => item === itemTwo, itemThree), null, 'no item detected');
+});
+
+test(`#detect finds w/ reverse`, (assert) => {
+  let list = new LinkedList();
+  let itemOne = new LinkedItem();
+  let itemTwo = new LinkedItem();
+  let itemThree = new LinkedItem();
+  list.append(itemOne);
+  list.append(itemTwo);
+  list.append(itemThree);
+  assert.equal(list.detect(item => item === itemOne, itemOne, true), itemOne, 'itemTwo detected');
+  assert.equal(list.detect(item => item === itemThree, itemThree, true), itemThree, 'itemThree');
+});
+
 test(`#objectAt looks up by index`, (assert) => {
   let list = new LinkedList();
   let itemOne = new LinkedItem();


### PR DESCRIPTION
This provides a high-level method to expand a range by checks on each marker. For example to expand the current cursor position to all markers with the same link:

```js
/* Collapsed means the cursor is not a selection */
if (editor.range.isCollapsed) {
  /* The marker (smallest unit markupable text) under the cursor */
  let marker = editor.range.head.marker;
  if (marker) {
    /* See if that marker has a link */
    let linkMarkup = marker.markups.find(m => m.tagName === 'a');
    if (linkMarkup) {
      /* If it has a link, expand the range to all markers with that link */
      let linkRange = editor.range.expandByMarker(marker => {
        return !!(marker.markups.find(m => m === linkMarkup);
      });
      /* Now you can use linkRange to do something to the whole link */
      editor.run(postEditor => {
        postEditor.removeMarkupFromRange(linkMarkup);
      });
    }
  }
}
```

TODO

* [x] ~~Should `expandRangeByMarker` be on the `section`? I think it probably should since the expansion is scoped to the section.~~ it will be on `range` instead. ~~`scanToMarker` will be on markers~~ derp this is just a detect with a step backwards. I've changed the expand logic to just use that.
* [x] Some further docs