### PR TITLE
Fixed broken logo link and removed Gitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![Dependency Status](https://david-dm.org/bustlelabs/mobiledoc-kit/master.svg)](https://david-dm.org/bustlelabs/mobiledoc-kit/master)
 [![devDependency Status](https://david-dm.org/bustlelabs/mobiledoc-kit/master/dev-status.svg)](https://david-dm.org/bustlelabs/mobiledoc-kit/master#info=devDependencies)
 
-![Mobiledoc Logo](https://raw.githubusercontent.com/bustlelabs/mobiledoc-kit/master/demo/public/images/mobiledoc-logo-color-small.png)
-
-[![Join the chat at https://gitter.im/bustlelabs/mobiledoc-kit](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bustlelabs/mobiledoc-kit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+![Mobiledoc Logo](https://bustlelabs.github.io/mobiledoc-kit/demo/mobiledoc-logo-color-small.png)
 
 Mobiledoc Kit (warning: beta) is a library for building WYSIWYG editors
 supporting rich content via cards.


### PR DESCRIPTION
Hey, noticed that link to image is not working. Took the new one from here: https://bustlelabs.github.io/mobiledoc-kit/demo/
This is the result:
![image](https://cloud.githubusercontent.com/assets/600203/22957234/f899f980-f2f4-11e6-988e-47a93aa63673.png)

Also removed a link to Gitter room, since it is depricated