### PR TITLE
Allows for the unregistering of custom key commands.

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -285,6 +285,20 @@ class Editor {
   }
 
   /**
+   * @param {String} name If the keyCommand event has a name attribute it can be removed.
+   * @public
+   */
+  unregisterKeyCommands(name) {
+    for(let i = this.keyCommands.length-1; i > -1; i--) {
+      let keyCommand = this.keyCommands[i];
+
+      if(keyCommand.name === name) {
+        this.keyCommands.splice(i,1);
+      }
+    }
+  }
+
+  /**
    * Convenience for {@link PostEditor#deleteAtPosition}. Deletes and puts the
    * cursor in the new position.
    * @public

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -443,3 +443,40 @@ test('returning false from key command still runs built-in functionality', (asse
 
   assert.equal($('#editor p').length, 2, 'has added a new paragraph');
 });
+
+test('new key commands can be registered and then unregistered', (assert) => {
+  editor = Helpers.mobiledoc.renderIntoAndFocusTail(editorElement, ({post, markupSection, marker}) => post([
+    markupSection('p', [marker('something')])
+  ]));
+
+  assert.ok(editor.hasCursor(), 'has cursor');
+  let passedEditorCount = 0;
+  let passedEditor;
+  editor.registerKeyCommand({
+    name: 'cut',
+    str: 'ctrl+x',
+    run(editor) { passedEditor = editor; passedEditorCount++; }
+  });
+
+  editor.registerKeyCommand({
+    name: 'cut',
+    str: 'ctrl+d',
+    run(editor) { passedEditor = editor; passedEditorCount++; }
+  });
+
+
+
+
+  Helpers.dom.triggerKeyCommand(editor, 'x', MODIFIERS.CTRL);
+  Helpers.dom.triggerKeyCommand(editor, 'd', MODIFIERS.CTRL);
+
+  assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
+  assert.ok(passedEditorCount === 2, 'the passedEditor has been called twice');
+
+  editor.unregisterKeyCommands('cut');
+
+  Helpers.dom.triggerKeyCommand(editor, 'x', MODIFIERS.CTRL);
+  Helpers.dom.triggerKeyCommand(editor, 'd', MODIFIERS.CTRL);
+
+  assert.ok(passedEditorCount === 2, 'the passedEditor has still only been called twice');
+});


### PR DESCRIPTION
- Allows users to add an optional `name` attribute to a keyCommand object as passed to the `registerKeyCommand` method.

- If the `name` attribute is added a new `unregisterKeyCommands` method will remove these key commands from the key command array.
Multiple key commands can have the same name, if so `unregisterKeyCommands` will remove all instances with that name.

Usage:

```javascript
  editor.registerKeyCommand({
    name: 'cut',
    str: 'ctrl+x',
    run(editor) { ... }
  });

  editor.unregisterKeyCommands('cut');
```