### PR TITLE
Constrain selection to editor element when probing for range

### DIFF
--- a/assets/demo/debug.css
+++ b/assets/demo/debug.css
@@ -1,3 +1,22 @@
 #toolbar button.active {
   font-weight: bold;
 }
+
+#error {
+  color: red;
+}
+
+#error .name {
+  font-weight: bold;
+}
+
+#editor {
+  outline: 1px solid black;
+  width: 200px;
+  min-height: 300px;
+}
+
+#editor[contenteditable="false"] {
+  color: #9e9e9e;
+  background-color: #f1f1f1;
+}

--- a/assets/demo/debug.html
+++ b/assets/demo/debug.html
@@ -3,43 +3,68 @@
 <head>
   <meta charset="utf-8">
   <title>Mobiledoc Kit Debug</title>
-</head>
-<body>
   <script src="../tests/jquery/jquery.js"></script>
   <script src="../global/mobiledoc-kit.js"></script>
   <script src="./debug.js"></script>
   <link rel="stylesheet" href="../css/mobiledoc-kit.css">
   <link rel="stylesheet" href="./debug.css">
+</head>
+<body>
+
+  <h1>Mobiledoc Kit Debug Page</h1>
+
+  <div id='toolbar'>
+    <button class='toggle' data-action='toggleSection' data-toggle='h1'>h1</button>
+    <button class='toggle' data-action='toggleSection' data-toggle='h2'>h2</button>
+    <button class='toggle' data-action='toggleMarkup' data-toggle='strong'>strong</button>
+    <button class='toggle' data-action='toggleMarkup' data-toggle='em'>em</button>
+    <button class='insert-atom' data-name='mention'>@mention</button>
+    <button class='insert-atom' data-name='click'>@click</button>
+    <button class='insert-card' data-name='movable'>movable card</button>
+    <button class='toggle-method' data-on='disableEditing' data-off='enableEditing'>
+      toggle editable
+    </button>
+  </div>
+
+  <div id="editor"></div>
+
+  <div>
+    <h2>Editor Info</h2>
+
+    <div>
+      <h3>Cursor</h3>
+      <div id='cursor'>
+      </div>
+    </div>
+
+    <div>
+      <h3>Post</h3>
+      <div id='post'>
+      </div>
+    </div>
+
+    <div>
+      <h3>Input Mode</h3>
+      <div id='input-mode'>
+      </div>
+    </div>
+
+    <div>
+      <h3>Error</h3>
+      <div id='error'>
+        <span class='name'></span>
+        <span class='message'></span>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <h2>Browser Info</h2>
+
+    <div>
+      <h3>Selection</h3>
+      <div id="selection"></div>
+    </div>
+  </div>
 </body>
-
-<div id='toolbar'>
-  <button class='toggle' data-action='toggleSection' data-toggle='h1'>h1</button>
-  <button class='toggle' data-action='toggleSection' data-toggle='h2'>h2</button>
-  <button class='toggle' data-action='toggleMarkup' data-toggle='strong'>strong</button>
-  <button class='toggle' data-action='toggleMarkup' data-toggle='em'>em</button>
-  <button class='insert-atom' data-name='mention'>@mention</button>
-  <button class='insert-atom' data-name='click'>@click</button>
-  <button class='insert-card' data-name='movable'>movable card</button>
-</div>
-
-<div id="editor" style='outline: 1px solid black; width: 200px; min-height: 300px;'></div>
-
-<div>
-  <h3>Cursor</h3>
-  <div id='cursor'>
-  </div>
-</div>
-
-<div>
-  <h3>Post</h3>
-  <div id='post'>
-  </div>
-</div>
-
-<div>
-  <h3>Input Mode</h3>
-  <div id='input-mode'>
-  </div>
-</div>
-
 </html>

--- a/assets/demo/debug.js
+++ b/assets/demo/debug.js
@@ -3,6 +3,14 @@
 
 var editor;
 
+function renderError(event) {
+  let error = event.error;
+  $('#error .name').text(error.name);
+  $('#error .message').text(error.message);
+}
+
+window.addEventListener('error', renderError);
+
 function renderSection(section) {
   return '[' +
     'Section: tagName ' + section.tagName +
@@ -27,6 +35,31 @@ function updateCursor() {
   var html = 'Head ' + head + '<br>Tail ' + tail;
 
   $('#cursor').html(html);
+}
+
+document.addEventListener('selectionchange', renderNativeSelection);
+
+function renderNativeSelection(event) {
+  let sel = window.getSelection();
+  let { anchorNode, focusNode, anchorOffset, focusOffset, isCollapsed, rangeCount } = sel;
+  if (anchorNode === null && focusNode === null) {
+    $('#selection').html(`<em>None</em>`);
+    return;
+  }
+  $('#selection').html(`
+    <div class='node'>Anchor: ${renderNode(anchorNode)} (${anchorOffset})</div>
+    <div class='node'>Focus: ${renderNode(focusNode)} (${focusOffset})</div>
+    <div>${isCollapsed ? 'Collapsed' : 'Not collapsed'}</div>
+    <div class='ranges'>Ranges: ${rangeCount}</div>
+  `);
+}
+
+function renderNode(node) {
+  let text = node.textContent.slice(0, 22);
+  if (node.textContent.length > 22) { text += '...'; }
+
+  let type = node.nodeType === Node.TEXT_NODE ? 'text' : `el (${node.tagName})`;
+  return `<span class='type'>${type}</span>: ${text}`;
 }
 
 function renderMarkup(markup) {
@@ -193,6 +226,18 @@ $(function () {
     let toggle = $(this).data('toggle');
 
     editor[action](toggle);
+  });
+
+  $('#toolbar button.toggle-method').click(function() {
+    let isOn = $(this).data('is-on') === 'true';
+    let methodOn = $(this).data('on');
+    let methodOff = $(this).data('off');
+
+    let nextState = isOn ? 'false' : 'true';
+    let method = isOn ? methodOff : methodOn;
+
+    $(this).data('is-on', nextState);
+    editor[method]();
   });
 
   $('#toolbar button.insert-atom').click(function() {

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -6,6 +6,7 @@ import { containsNode } from '../utils/dom-utils';
 import Position from './cursor/position';
 import Range from './cursor/range';
 import { DIRECTION } from '../utils/key';
+import { constrainSelectionTo } from '../utils/selection-utils';
 
 export { Position, Range };
 
@@ -61,7 +62,9 @@ const Cursor = class Cursor {
   get offsets() {
     if (!this.hasCursor()) { return Range.blankRange(); }
 
-    const { selection, renderTree } = this;
+    let { selection, renderTree } = this;
+    let parentNode = this.editor.element;
+    selection = constrainSelectionTo(selection, parentNode);
 
     const {
       headNode, headOffset, tailNode, tailOffset, direction

--- a/tests/unit/utils/cursor-position-test.js
+++ b/tests/unit/utils/cursor-position-test.js
@@ -469,6 +469,44 @@ test('#fromNode when node is card section element or next to it', (assert) => {
                          leftPos, 'card div offset 1');
 });
 
+/**
+ * When triple-clicking text in a disabled editor, some browsers will
+ * expand the selection to include the start of a node outside the editor.
+ * See: https://github.com/bustlelabs/mobiledoc-kit/issues/486
+ *
+ * Chrome and Safari appear to extend the selection to the next node in the document
+ * that has a textNode in it. Firefox does not suffer from this issue.
+ */
+test('#fromNode when selection is outside (after) the editor element', function(assert) {
+  let done = assert.async();
+  let div$ = $('<div><p>AFTER</p></div>').insertAfter($(editorElement));
+  let p = div$[0].firstChild;
+
+  editor = Helpers.mobiledoc.renderInto(editorElement,
+    ({post, markupSection, marker}) => post([markupSection('p', [marker('abcdef')])])
+  );
+
+  // If the editor isn't disabled, some browsers will "fix" the selection range we are
+  // about to add by constraining it within the contentEditable container div
+  editor.disableEditing();
+
+  let anchorNode = $(editorElement).find('p:contains(abcdef)')[0].firstChild;
+  let focusNode = p;
+  Helpers.dom.selectRange(anchorNode, 0, focusNode, 0);
+
+  Helpers.wait(() => {
+    assert.ok(window.getSelection().anchorNode === anchorNode, 'precond - anchor node');
+    assert.ok(window.getSelection().focusNode === focusNode, 'precond - focus node');
+    let range = editor.range;
+
+    assert.positionIsEqual(range.head, editor.post.headPosition(), 'head');
+    assert.positionIsEqual(range.tail, editor.post.tailPosition(), 'tail');
+
+    div$.remove();
+    done();
+  });
+});
+
 test('Position cannot be on list section', (assert) => {
   let post = Helpers.postAbstract.build(({post, listSection, listItem}) => {
     return post([listSection('ul', [listItem()])]);

--- a/tests/unit/utils/cursor-position-test.js
+++ b/tests/unit/utils/cursor-position-test.js
@@ -287,50 +287,22 @@ test('#moveWord across markerable/non-markerable section boundaries', (assert) =
                          'beforeTail -> cardTail');
 });
 
-function buildPostWithTextAndAtom(textWithAtoms) {
-  return Helpers.postAbstract.build(({post, markupSection, marker, atom}) => {
-    let {markers} = textWithAtoms.split("").reduce(({markerText, markers}, ch, index) => {
-      let isLast = index === textWithAtoms.length - 1;
-
-      if (ch === 'A') { // "A" is for "atom"
-        if (markerText.length) {
-          markers.push(marker(markerText));
-          markerText = '';
-        }
-        markers.push(atom('the-atom'));
-      } else {
-        markerText += ch;
-      }
-
-      if (isLast && markerText.length) {
-        markers.push(marker(markerText));
-      }
-      return {markerText, markers};
-    }, {markerText: '', markers: []});
-
-    return post([markupSection('p', markers)]);
-  });
-}
-
 test('#moveWord with atoms (backward)', (assert) => {
   let expectations = [
-    ['abc A|', 'abc |A'],
-    ['abc |A', '|abc A'],
-    ['A|', '|A'],
-    ['A  |', 'A|  '],
-    ['AA|', 'A|A'],
-    ['|A', '|A']
+    ['abc @|', 'abc |@'],
+    ['abc |@', '|abc @'],
+    ['@|', '|@'],
+    ['@  |', '@|  '],
+    ['@@|', '@|@'],
+    ['@|@', '|@@'],
+    ['|@@', '|@@']
   ];
 
   expectations.forEach(([before, after]) => {
-    let textWithAtoms = before.replace('|', '');
-    let beforeIndex = before.indexOf('|');
-    let afterIndex = after.indexOf('|');
-
-    let post = buildPostWithTextAndAtom(textWithAtoms);
+    let { post, range: { head: pos } } = Helpers.postAbstract.buildFromText(before);
+    let { range: { head: nextPos } } = Helpers.postAbstract.buildFromText(after);
     let section = post.sections.head;
-    let pos = section.toPosition(beforeIndex);
-    let nextPos = section.toPosition(afterIndex);
+    nextPos = section.toPosition(nextPos.offset);
 
     assert.positionIsEqual(pos.moveWord(BACKWARD), nextPos,
                            `move word with atoms "${before}" -> "${after}"`);
@@ -363,22 +335,21 @@ test('#moveWord in text (forward)', (assert) => {
 
 test('#moveWord with atoms (forward)', (assert) => {
   let expectations = [
-    ['|A', 'A|'],
-    ['A|', 'A|'],
-    ['|  A', '  A|'],
-    ['abc| A', 'abc A|'],
-    ['A|A', 'AA|']
+    ['|@', '@|'],
+    ['@|', '@|'],
+    ['|  @', '  @|'],
+    ['|  @ x', '  @ |x'],
+    ['abc| @', 'abc @|'],
+    ['|@@', '@|@'],
+    ['@|@', '@@|'],
+    ['@@|', '@@|']
   ];
 
   expectations.forEach(([before, after]) => {
-    let textWithAtoms = before.replace('|', '');
-    let beforeIndex = before.indexOf('|');
-    let afterIndex = after.indexOf('|');
-
-    let post = buildPostWithTextAndAtom(textWithAtoms);
+    let { post, range: { head: pos } } = Helpers.postAbstract.buildFromText(before);
+    let { range: { head: nextPos } } = Helpers.postAbstract.buildFromText(after);
     let section = post.sections.head;
-    let pos = section.toPosition(beforeIndex);
-    let nextPos = section.toPosition(afterIndex);
+    nextPos = section.toPosition(nextPos.offset);
 
     assert.positionIsEqual(pos.moveWord(FORWARD), nextPos,
                            `move word with atoms "${before}" -> "${after}"`);


### PR DESCRIPTION
This fixes an issue where `Position.fromNode` would be called with a node
that is outside the editor element, triggering a failed assertion.

Now, Cursor constrains the selection to only include the extent inside the
editor element before looking up Positions from the anchor and focus nodes.

Most of the time this situation is prevented by the browser (it refuses to
allow one to create a selection that crosses into or out of the
contentEditable div), but when `editor.disableEditing()` is called, a user
can triple-click the last part of the mobiledoc document which causes the
browser (for Chrome and Safari, but not Firefox) to extend the selection
*outside* the editor's element.

Fixes #486 as reported by @YoranBrondsema